### PR TITLE
chunks: Add --prelude, implement --dry-run.

### DIFF
--- a/bin/mqsub
+++ b/bin/mqsub
@@ -125,7 +125,7 @@ class PbsJobInfo:
 
 class script_format:
     @staticmethod
-    def header(outfile):
+    def header(outfile, prelude=None):
         print('#!/bin/bash -l',file=outfile)
         print('#PBS -l ncpus={}'.format(args.cpus),file=outfile)
         print('#PBS -l ngpus={}'.format(args.gpu),file=outfile)        
@@ -148,6 +148,8 @@ class script_format:
 #            print('. /pkg/suse12/software/miniconda3/4.5.12/etc/profile.d/conda.sh',file=outfile)
 #            print('conda activate',file=outfile)
             print("conda activate '{}'".format(current_conda_env),file=outfile)
+        if prelude:
+            print(prelude+'\n\n',file=outfile)
         if args.command_file and (args.chunk_num or args.chunk_size):
             print("\nNUM_FAILED=0\n", file=outfile)
         if args.command_file and (args.chunk_num or args.chunk_size):
@@ -287,6 +289,7 @@ if __name__ == '__main__':
     parser.add_argument('--command-file',dest='command_file', help="A file with list of newline separated commands to be split into chunks and submitted. One command per line. mqsub --command-file <file.txt> --chunk-num <int>")
     parser.add_argument('--chunk-num',type=int,dest='chunk_num', help='Number of chunks to divide the commands (from --command-file) into')
     parser.add_argument('--chunk-size',type=int,dest='chunk_size', help='Number of commands (from --command-file) per a chunk ')
+    parser.add_argument('--prelude', help='Code from this file will be run before each chunk')
     parser.add_argument('command',nargs='*',help='command to be run')
     args = parser.parse_args()
 
@@ -353,6 +356,10 @@ if __name__ == '__main__':
 #############################################
 
     if args.command_file and (args.chunk_num or args.chunk_size):
+        if args.prelude:
+            logging.info("Reading prelude from {}".format(args.prelude))
+            with open(args.prelude) as f:
+                prelude = f.read()
         with open(args.command_file) as f:
             chunkID = 1
             commands = f.read().splitlines()
@@ -379,11 +386,14 @@ if __name__ == '__main__':
             for chunk in chunks:
                 with open(command_name + str(chunkID) +'.sh', 'w') as outfile:
                     chunk = "\n".join(s for s in chunk)
-                    script_format.header(outfile)
+                    script_format.header(outfile, prelude if args.prelude else None)
                 chunkID = chunkID + 1
 
-                script_format.submit(outfile)
-
+                if args.dry_run:
+                    print(open(os.path.abspath(outfile.name)).read())
+                else:
+                    script_format.submit(outfile)
+                
                 os.remove(os.path.abspath(outfile.name))
 
 


### PR DESCRIPTION
Thoughts @sternp ?

I wanted this so I could copy some db type files into $TMPDIR once for a whole batch of commands.

I suppose it could be improved slightly by croaking if prelude is specified by command-file / chunks aren't on the command line.

Thanks,
ben