### PR TITLE
snakemake_mqsub: Proof of concept.

### DIFF
--- a/bin/mqstat
+++ b/bin/mqstat
@@ -97,6 +97,10 @@ class JobsCount:
         self.num_running = 0
         self.num_queued = 0
         self.num_other = 0
+        self.num_running_cpus = 0
+        self.num_total_cpus = 0
+        self.ram_running = 0
+        self.ram_total = 0
 
 def get_non_microbiome_jobs():
     all_my_jobs = run('qstat -u `whoami`').decode('latin-1').split('\n')[5:]
@@ -110,8 +114,14 @@ def get_non_microbiome_jobs():
         if 'microbi' in splits[2]:
             continue
         else:
+            cpus = int(splits[6])
+            ram = int(splits[7].replace('gb',''))
+            jc.num_total_cpus += cpus
+            jc.ram_total += ram
             if splits[9] == 'R':
                 jc.num_running += 1
+                jc.num_running_cpus += cpus
+                jc.ram_running += ram
             elif splits[9] == 'Q':
                 jc.num_queued += 1
             else:
@@ -330,6 +340,16 @@ if __name__ == '__main__':
             non_microbiome_jobs.num_running,
             non_microbiome_jobs.num_running + non_microbiome_jobs.num_queued + non_microbiome_jobs.num_other,
             non_microbiome_jobs.num_running/(non_microbiome_jobs.num_running + non_microbiome_jobs.num_queued + non_microbiome_jobs.num_other)*100 if (non_microbiome_jobs.num_running + non_microbiome_jobs.num_queued + non_microbiome_jobs.num_other) > 0 else 0))
+        print("{} lyra queue CPUs running: {} / {} ({:.1f}%)".format(
+            user,
+            non_microbiome_jobs.num_running_cpus,
+            non_microbiome_jobs.num_total_cpus,
+            non_microbiome_jobs.num_running_cpus/non_microbiome_jobs.num_total_cpus*100 if non_microbiome_jobs.num_total_cpus > 0 else 0))
+        print("{} lyra queue RAM running: {} / {} GB ({:.1f}%)".format(
+            user,
+            non_microbiome_jobs.ram_running,
+            non_microbiome_jobs.ram_total,
+            non_microbiome_jobs.ram_running/non_microbiome_jobs.ram_total*100 if non_microbiome_jobs.ram_total > 0 else 0))
         if non_microbiome_jobs.num_other > 0:
             print("NOTE: {} non-microbiome jobs of {} were neither running nor queued".format(non_microbiome_jobs.num_other, user))
 

--- a/bin/snakemake_mqsub
+++ b/bin/snakemake_mqsub
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+import shutil
+
+from snakemake.utils import read_job_properties
+
+## Code below copied from the extern python package. Copy the code here so there are no dependencies.
+
+def run(command, stdin=None):
+    '''
+    Run a subprocess.check_output() with the given command with
+    'bash -c command'
+    returning the stdout. If the command fails (i.e. has a non-zero exitstatus),
+    raise a ExternCalledProcessError that includes the $stderr as part of
+    the error message
+
+    Parameters
+    ----------
+    command: str
+        command to run
+    stdin: str or None
+        stdin to be provided to the process, to subprocess.communicate.
+
+    Returns
+    -------
+    Standard output of the run command
+
+    Exceptions
+    ----------
+    extern.ExternCalledProcessError including stdout and stderr of the run
+    command should it return with non-zero exit status.
+    '''
+    #logging.debug("Running extern cmd: %s" % command)
+
+    using_stdin = stdin is not None
+    process = process = subprocess.Popen(
+        ["bash",'-o','pipefail',"-c", command],
+        stdin= (subprocess.PIPE if using_stdin else None),
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate(stdin)
+
+    if process.returncode != 0:
+        raise ExternCalledProcessError(process, command, stdout.decode(), stderr.decode())
+    return stdout
+
+#%% CLASSES ##########
+######################
+
+class ExternCalledProcessError(subprocess.CalledProcessError):
+    def __init__(self, completed_process, command, stdout, stderr):
+        self.command = command
+        self.returncode = completed_process.returncode
+        self.stderr = stderr
+        self.stdout = stdout
+        self.completed_process = completed_process
+
+    def __str__(self):
+        return "Command %s returned non-zero exit status %i.\n"\
+            "STDERR was: %sSTDOUT was: %s" % (
+                self.command,
+                self.returncode,
+                self.stderr,
+                self.stdout)
+
+if __name__ == '__main__':
+
+    jobscript = sys.argv[1]
+    job_properties = read_job_properties(jobscript)
+
+    threads = job_properties['threads']
+    mem_mb = job_properties['resources']['mem_mb']
+    mem_gb = int(mem_mb / 1000)
+
+    if 'runtime' in job_properties['resources']:
+        runtime_mins = job_properties['resources']['runtime']
+        runtime_hours = "--hours {}".format(int(runtime_mins / 60))
+    else:
+        runtime_hours = ''
+
+
+    if 'queue' in job_properties['resources']:
+        queue = '-q '+job_properties['resources']['queue']
+    else:
+        queue = ''
+
+    # shutil.copyfile(jobscript, "/tmp/benjob.sh")
+    mqsub_stdout = run("mqsub --seg --no-email --quiet --bg -t {threads} -m {mem} {hours} --script {script} {queue} 2>&1".format(
+        threads=threads, script=jobscript, mem=mem_gb, hours=runtime_hours, queue=queue))
+    with open("/tmp/benout", 'w') as f:
+        f.write(mqsub_stdout.decode())
+    
+    # Print the pbs ID as expected by snakemake
+    correct_line = [line for line in mqsub_stdout.decode().split('\n') if line.startswith('qsub stdout: ')]
+    if len(correct_line) != 1:
+        raise ValueError("mqsub returned unexpected output: {}".format(mqsub_stdout.decode()))
+    else:
+        print(correct_line[0].strip().replace('qsub stdout: ',''))

--- a/bin/snakemake_mqsub
+++ b/bin/snakemake_mqsub
@@ -74,7 +74,7 @@ if __name__ == '__main__':
     mem_gb = int(mem_mb / 1000)
 
     if 'runtime' in job_properties['resources']:
-        runtime_mins = job_properties['resources']['runtime']
+        runtime_mins = job_properties['resources']['runtime'] # Fails with snakemake == 7.16.0, but works with 7.30.1
         runtime_hours = "--hours {}".format(int(runtime_mins / 60))
     else:
         runtime_hours = ''
@@ -85,11 +85,8 @@ if __name__ == '__main__':
     else:
         queue = ''
 
-    # shutil.copyfile(jobscript, "/tmp/benjob.sh")
     mqsub_stdout = run("mqsub --seg --no-email --quiet --bg -t {threads} -m {mem} {hours} --script {script} {queue} 2>&1".format(
         threads=threads, script=jobscript, mem=mem_gb, hours=runtime_hours, queue=queue))
-    with open("/tmp/benout", 'w') as f:
-        f.write(mqsub_stdout.decode())
     
     # Print the pbs ID as expected by snakemake
     correct_line = [line for line in mqsub_stdout.decode().split('\n') if line.startswith('qsub stdout: ')]

--- a/snakemake_qsub/Snakefile
+++ b/snakemake_qsub/Snakefile
@@ -1,0 +1,9 @@
+rule sleep:
+    output:
+        done = "snakemake_qsub.done"
+    threads: 2
+    resources:
+        mem = "3GB",
+        runtime = "120m",
+    shell:
+        "sleep 60 && touch {output.done}"


### PR DESCRIPTION
With this, we can use snakemake with the --cluster command, to run individual rules via the queue e.g.

```
$ snakemake --use-conda -c 1000 --rerun-incomplete --cluster ~/git/hpc_scripts/bin/snakemake_mqsub --jobs 1000
```

snakemake_mqsub is a wrapper script that calls mqsub after transforming the inputs provided by snakemake. 

Right now it understands threads, runtime and mem, which are standard snakemake ones, plus a special `queue` one so that you can use the lyra queue if needed.

Here's an example snakemake rule that uses it

```
rule lorikeet:
    input:
        bam_merge_done = "snakedata/combined_bams/all_merged.done",
        # bam_symlink_done = "snakedata/combined_bams/all_symlinked.done",
    output:
        done = "snakedata/lorikeet/lorikeet-{species_accession}.done",
        outdir = directory("snakedata/lorikeet/lorikeet-{species_accession}"),
    threads: 64
    conda:
        "lorikeet-dev"
    resources:
        mem = "500GB", # likely overkill
        runtime = "1w",
    log:
        "snakedata/lorikeet/{species_accession}.log"
    params:
        genome_location = lambda wildcards: methanofloren_genome_locations[wildcards.species_accession],
        bam_paths = lambda wildcards: " ".join(
            [f"snakedata/combined_bams/{sample}.bam" for sample in single_and_paired_samples] + 
            [f"paired_bams/coverm-genome.{sample}_1.fastq.gz.bam" for sample in paired_only_samples] +
            [f"single_bams/coverm-genome.{sample}.fastq.gz.bam" for sample in single_only_samples])
    shell:
        "LD_LIBRARY_PATH=~/e/lorikeet-dev/lib ~/m/lorikeet/mess/lorikeet-0.8.1/bin/lorikeet call -t {threads} --genome-fasta-files {params.genome_location} --output-directory {output.outdir} -b {params.bam_paths} &> {log} && touch {output.done}"
```

Thoughts @sternp ? It would be good to integrate this into Aviary, but first things first.

I'd like to know how to run some rules locally, and some on the cluster - best solution I have for that is to provide a snakemake group so that all small jobs are run in the same pbs job.

Just using `snakemake --cluster qsub` doesn't work properly because that command doesn't respect the resource requests, not exactly sure why, but making our own wrapper also lets us default to the microbiome queue.