### PR TITLE
mqstat: Also report cluster-wide usage.

### DIFF
--- a/bin/mqstat
+++ b/bin/mqstat
@@ -380,3 +380,33 @@ if __name__ == '__main__':
                 num_non_microbiome_cpus_running,
                 num_non_microbiome_cpus_running/total_cpus*100 if total_cpus > 0 else 0))
 
+        # Get an overall state of the cluster
+        pbsnodeinfo = run('pbsnodeinfo').decode()
+        # Node    :   cputype |        cpuarch ;    cpu usage;    mem usage; gputype; gpu usage
+        # =====================================================================================
+        # cl4n001 : E7-8890v4 |       avx,avx2 ;  6 / 192 cpus; 500 / 5794 GB
+        # cl4n002 :      6140 |avx,avx2,avx512 ;  8 / 36 cpus;  32 / 186 GB;  P100; 1 / 4 gpus
+        # cl4n003 :      6140 |avx,avx2,avx512 ;  0 / 36 cpus;   0 / 186 GB;  P100; 0 / 4 gpus
+        # cl4n007 :      6140 |avx,avx2,avx512 ; 35 / 36 cpus; 324 / 376 GB   
+        line_re = re.compile(r'^(cl\d)\S+ *: *.*?; *(\d+) / (\d+) cpus')
+        cpu_usage = {}
+        for line in pbsnodeinfo.split('\n'):
+            if line.startswith('Node') or line.startswith('===') or line.strip() == '':
+                continue
+            matches = line_re.match(line)
+            if matches:
+                node_group = matches.group(1)
+                num_cpus_used = int(matches.group(2))
+                num_cpus = int(matches.group(3))
+                if node_group not in cpu_usage:
+                    cpu_usage[node_group] = {'used': 0, 'total': 0}
+                cpu_usage[node_group]['used'] += num_cpus_used
+                cpu_usage[node_group]['total'] += num_cpus
+            else:
+                print("WARNING: Could not parse pbsnodeinfo line: {}".format(line))
+        for node_group in sorted(cpu_usage.keys()):
+            print("Node group {}: {} / {} CPUs ({:.1f}%)".format(
+                node_group,
+                cpu_usage[node_group]['used'],
+                cpu_usage[node_group]['total'],
+                cpu_usage[node_group]['used']/cpu_usage[node_group]['total']*100 if cpu_usage[node_group]['total'] > 0 else 0))


### PR DESCRIPTION
```
$ ~/git/hpc_scripts/bin/mqstat
Microbiome group jobs running: 8 / 10 (80.00%)
Microbiome group CPUs utilized: 512 / 512 (100.00%)
Microbiome group CPUs queued: 128
woodcrob jobs running: 0 / 0 (0.0%)
woodcrob CPUs running: 0 / 512 (0.0%)
woodcrob CPUs queued: 0
woodcrob lyra queue jobs running: 162 / 1339 (12.1%)
woodcrob lyra queue CPUs running: 648 / 5356 (12.1%)
woodcrob lyra queue RAM running: 1296 / 10712 GB (12.1%)
NOTE: 5 non-microbiome jobs of woodcrob were neither running nor queued
Node group cl4: 3158 / 3720 CPUs (84.9%)
Node group cl5: 4422 / 6288 CPUs (70.3%)
```

Not ideal as it doesn't account for RAM or GPUs, but a good indicator overall I think, for now.