### PR TITLE
Snakemake harden & cmr bashrc setup

### DIFF
--- a/bin/snakemake_mqstat
+++ b/bin/snakemake_mqstat
@@ -2,6 +2,7 @@
 import os
 import sys
 import subprocess
+import time
 
 ## Code below copied from the extern python package. Copy the code here so there are no dependencies.
 
@@ -65,7 +66,26 @@ if __name__ == '__main__':
 
     jobid = sys.argv[1]
 
-    output = run("qstat -x -f %s" % jobid).decode()
+    num_retry = 0
+    error = None
+    while True:
+        if num_retry < 10:
+            try:
+                output = run("qstat -x -f %s" % jobid).decode()
+                break
+            except ExternCalledProcessError as e:
+                # Sometimes get transient errors like:
+
+                # ExternCalledProcessError: Command qstat -x -f 5030967.pbs returned non-zero exit status 255.
+                # STDERR was: Communication failure.
+                # qstat: cannot connect to server pbs-primary (errno=15031)
+
+                # sleep for 10 seconds and try again
+                time.sleep(10)
+                num_retry += 1
+                error = e
+        else:
+            raise Exception("Failed to get job status after 10 retries, last error was:\n%s" % error)
 
     states = {}
     states['B'] = 'running' #'Array job has at least one subjob running'
@@ -82,9 +102,17 @@ if __name__ == '__main__':
     states['X'] = 'success' #'Subjob has completed execution or has been deleted'
 
     job_state_line = None
+    exit_status = None
     for line in output.split('\n'):
         if line.startswith('    job_state ='):
             job_state_line = line.replace('    job_state =','').strip()
-            break
+        elif line.startswith('    Exit_status = '):
+            exit_status = int(line.replace('    Exit_status = ','').strip())
     status = states[job_state_line]
-    print(status)
+    if job_state_line == 'F':
+        if exit_status != 0:
+            print('failed')
+        else:
+            print('success')
+    else:
+        print(status)

--- a/bin/snakemake_mqsub
+++ b/bin/snakemake_mqsub
@@ -69,6 +69,8 @@ if __name__ == '__main__':
 
     parser.add_argument('--queue', help='Queue to submit to [default = mqsub default]')
     parser.add_argument('--segregated-log-files', action='store_true', help='Put log files in ~/qsub_logs/<date>/<directory> instead of the current working directory.')
+    # --dry-run
+    parser.add_argument('--dry-run', action='store_true')
     parser.add_argument('jobscript', help='Script to submit')
 
     args = parser.parse_args()
@@ -111,11 +113,16 @@ if __name__ == '__main__':
         job_name=job_name, extra_mqsub_args=extra_mqsub_args,
         threads=threads, script=jobscript, mem=mem_gb, hours=runtime_hours, queue=queue, 
         segregated_log_files_arg=segregated_log_files_arg)
-    mqsub_stdout = run(cmd)
-    
-    # Print the pbs ID as expected by snakemake
-    correct_line = [line for line in mqsub_stdout.decode().split('\n') if line.startswith('qsub stdout: ')]
-    if len(correct_line) != 1:
-        raise ValueError("mqsub returned unexpected output: {}".format(mqsub_stdout.decode()))
+
+    if args.dry_run:
+        print(cmd)
+        sys.exit(1) # exit 1 so that if this is through an actual snakemake run it quits immediately
     else:
-        print(correct_line[0].strip().replace('qsub stdout: ',''))
+        mqsub_stdout = run(cmd)
+        
+        # Print the pbs ID as expected by snakemake
+        correct_line = [line for line in mqsub_stdout.decode().split('\n') if line.startswith('qsub stdout: ')]
+        if len(correct_line) != 1:
+            raise ValueError("mqsub returned unexpected output: {}".format(mqsub_stdout.decode()))
+        else:
+            print(correct_line[0].strip().replace('qsub stdout: ',''))

--- a/cmr_bashrc_extras.bash
+++ b/cmr_bashrc_extras.bash
@@ -41,3 +41,7 @@ case $- in *i*) echo "** cl5n006 disk usage (%): `cat /work/microbiome/cl5n006_d
 case $- in *i*) echo "** cl5n007 disk usage (%): `cat /work/microbiome/cl5n007_disk_usage` **"; esac
 case $- in *i*) echo "** cl5n008 disk usage (%): `cat /work/microbiome/cl5n008_disk_usage` **"; esac
 case $- in *i*) echo "** cl5n009 disk usage (%): `cat /work/microbiome/cl5n009_disk_usage` **"; esac
+
+# Setup snakemake config directories so it interfaces well with the PBS system
+mkdir -p ~/.config/snakemake
+cd ~/.config/snakemake && ln -sf /work/microbiome/sw/hpc_scripts/snakemake_configs/* . && cd ~

--- a/snakemake_configs/mqsub-lyra/config.yaml
+++ b/snakemake_configs/mqsub-lyra/config.yaml
@@ -1,0 +1,6 @@
+cluster: snakemake_mqsub --segregated-log-files --queue lyra
+cluster-status: snakemake_mqstat
+jobs: 10000
+cluster-cancel: qdel
+use-conda: true
+conda-frontend: mamba

--- a/snakemake_configs/mqsub/config.yaml
+++ b/snakemake_configs/mqsub/config.yaml
@@ -1,0 +1,6 @@
+cluster: snakemake_mqsub --segregated-log-files --queue microbiome
+cluster-status: snakemake_mqstat
+jobs: 10000
+cluster-cancel: qdel
+use-conda: true
+conda-frontend: mamba


### PR DESCRIPTION
There's some hardening code here, plus a call in cmr_bash_extras to setup people's snakemake configs for profiles.

It would be to get someone else than me to test this out - would you mind plesae @sternp ? e.g. make a small snakemake pipeline and then run it using `--profile mqsub-lyra` for instance?

Decided the `mqsub` profile should submit to `microbiome` not `lyra` to be in line with mqsub itself.