### PR TITLE
snakemake_mqsub: Handle when mem_mb is missing in snakemake v8.

### DIFF
--- a/bin/snakemake_mqsub
+++ b/bin/snakemake_mqsub
@@ -79,8 +79,12 @@ if __name__ == '__main__':
     job_properties = read_job_properties(jobscript)
 
     threads = job_properties['threads']
-    mem_mb = job_properties['resources']['mem_mb']
-    mem_gb = int(mem_mb / 1000)
+    if 'mem_mb' in job_properties['resources']:
+        mem_mb = job_properties['resources']['mem_mb']
+        mem_gb = int(mem_mb / 1000)
+        mem_argument = "-m {}".format(mem_gb)
+    else:
+        mem_argument = ''
 
     if 'runtime' in job_properties['resources']:
         runtime_mins = job_properties['resources']['runtime'] # Fails with snakemake == 7.16.0, but works with 7.30.1
@@ -109,9 +113,9 @@ if __name__ == '__main__':
     # But currently mqsub ignores this anyway, so definiting --name has no effect.
     job_name = os.path.basename(jobscript).replace('snakemake','')
 
-    cmd = "mqsub --no-email --quiet --bg --name {job_name} -t {threads} -m {mem} {hours} --script {script} {queue} {segregated_log_files_arg} {extra_mqsub_args} 2>&1".format(
+    cmd = "mqsub --no-email --quiet --bg --name {job_name} -t {threads} {mem} {hours} --script {script} {queue} {segregated_log_files_arg} {extra_mqsub_args} 2>&1".format(
         job_name=job_name, extra_mqsub_args=extra_mqsub_args,
-        threads=threads, script=jobscript, mem=mem_gb, hours=runtime_hours, queue=queue, 
+        threads=threads, script=jobscript, mem=mem_argument, hours=runtime_hours, queue=queue, 
         segregated_log_files_arg=segregated_log_files_arg)
 
     if args.dry_run:

--- a/snakemake_configs/mqsub-lyra/config.v8+.yaml
+++ b/snakemake_configs/mqsub-lyra/config.v8+.yaml
@@ -1,0 +1,8 @@
+executor: cluster-generic
+cluster-generic-submit-cmd: snakemake_mqsub --segregated-log-files --queue lyra
+cluster-generic-status-cmd: snakemake_mqstat
+jobs: 10000
+cluster-generic-cancel-cmd: qdel
+use-conda: true
+conda-frontend: mamba
+rerun-incomplete: true # Without this, snakemake will attempt to resume when rerunning a rule, which fails immediately without error

--- a/snakemake_configs/mqsub/config.v8+.yaml
+++ b/snakemake_configs/mqsub/config.v8+.yaml
@@ -1,0 +1,8 @@
+executor: cluster-generic
+cluster-generic-submit-cmd: snakemake_mqsub --segregated-log-files
+cluster-generic-status-cmd: snakemake_mqstat
+jobs: 10000
+cluster-generic-cancel-cmd: qdel
+use-conda: true
+conda-frontend: mamba
+rerun-incomplete: true # Without this, snakemake will attempt to resume when rerunning a rule, which fails immediately without error


### PR DESCRIPTION
Otherwise in snakemake 8 it fails when mem_mb is missing from the resources section.