### PR TITLE
mqsub: add --ensure-cpu-usage self-monitoring

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ echo.done
 __pycache__/
 qstat_filter/target/
 singularity/ai_tool.sif
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/bin/mqsub
+++ b/bin/mqsub
@@ -29,6 +29,104 @@ import re
 
 DEFAULT_RAM_TO_CPU_RATIO = 1495.0 / 192.0
 
+ENSURE_CPU_USAGE_EXIT_STATUS = 151
+
+ENSURE_CPU_USAGE_SHELL_SNIPPET = r'''
+# --- mqsub --ensure-cpu-usage monitor ---
+export MQSUB_ENSURE_SENTINEL="${TMPDIR:-/tmp}/mqsub_ensure_cpu_fail.${PBS_JOBID:-$$}"
+export MQSUB_ENSURE_SHELL_PID=$$
+rm -f "$MQSUB_ENSURE_SENTINEL"
+
+_mqsub_ensure_cleanup() {
+    local _ec=$?
+    if [ -n "${MQSUB_ENSURE_MONITOR_PID:-}" ]; then
+        kill "$MQSUB_ENSURE_MONITOR_PID" 2>/dev/null
+        wait "$MQSUB_ENSURE_MONITOR_PID" 2>/dev/null
+    fi
+    if [ -f "$MQSUB_ENSURE_SENTINEL" ]; then
+        rm -f "$MQSUB_ENSURE_SENTINEL"
+        exit 151
+    fi
+    exit $_ec
+}
+trap _mqsub_ensure_cleanup EXIT TERM
+
+python3 -u - <<'_MQSUB_ENSURE_PY_EOF' &
+import json, os, signal, subprocess, sys, time
+
+INTERVAL = int(os.environ['MQSUB_ENSURE_INTERVAL'])
+THRESHOLD = float(os.environ['MQSUB_ENSURE_THRESHOLD'])
+NCPUS = int(os.environ['MQSUB_ENSURE_NCPUS'])
+JOB_ID = os.environ.get('PBS_JOBID', '')
+SHELL_PID = int(os.environ['MQSUB_ENSURE_SHELL_PID'])
+SENTINEL = os.environ['MQSUB_ENSURE_SENTINEL']
+
+def parse_pbs_time(s):
+    if not s:
+        return 0
+    try:
+        parts = str(s).split(':')
+        if len(parts) == 3:
+            return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+        if len(parts) == 2:
+            return int(parts[0]) * 60 + int(parts[1])
+        return int(parts[0])
+    except (ValueError, IndexError):
+        return 0
+
+def fetch():
+    if not JOB_ID:
+        return None, None
+    try:
+        out = subprocess.check_output(
+            ['qstat', '-x', '-f', JOB_ID, '-F', 'json'],
+            stderr=subprocess.DEVNULL).decode()
+        info = json.loads(out)['Jobs'][JOB_ID]
+        r = info.get('resources_used') or {}
+        return parse_pbs_time(r.get('cput')), parse_pbs_time(r.get('walltime'))
+    except Exception:
+        return None, None
+
+baseline_cput, baseline_walltime = fetch()
+if baseline_cput is None:
+    baseline_cput, baseline_walltime = 0, 0
+
+while True:
+    time.sleep(INTERVAL)
+    cput, walltime = fetch()
+    if cput is None:
+        continue
+    delta_cput = cput - baseline_cput
+    delta_walltime = walltime - baseline_walltime
+    if delta_walltime <= 0:
+        continue
+    expected = delta_walltime * NCPUS
+    ratio = (delta_cput / expected * 100.0) if expected > 0 else 100.0
+    if ratio < THRESHOLD:
+        sys.stderr.write(
+            "mqsub: --ensure-cpu-usage check failed for job {}: over the last {}s of "
+            "walltime, cput delta was {}s with {} CPUs allocated ({:.1f}%, below "
+            "threshold of {:.1f}%). Cancelling job.\n".format(
+                JOB_ID, delta_walltime, delta_cput, NCPUS, ratio, THRESHOLD))
+        sys.stderr.flush()
+        try:
+            open(SENTINEL, 'w').close()
+        except Exception:
+            pass
+        try:
+            os.killpg(os.getpgid(SHELL_PID), signal.SIGTERM)
+        except Exception:
+            try:
+                os.kill(SHELL_PID, signal.SIGTERM)
+            except Exception:
+                pass
+        sys.exit(0)
+    baseline_cput, baseline_walltime = cput, walltime
+_MQSUB_ENSURE_PY_EOF
+MQSUB_ENSURE_MONITOR_PID=$!
+# --- end mqsub --ensure-cpu-usage monitor ---
+'''
+
 ## Code below copied from the extern python package. Copy the code here so there are no dependencies.
 
 def run(command, stdin=None):
@@ -199,7 +297,12 @@ class script_format:
         except:
             current_conda_env = None
         if current_conda_env:
-            print("conda activate '{}'".format(current_conda_env),file=outfile)  
+            print("conda activate '{}'".format(current_conda_env),file=outfile)
+        if args.ensure_cpu_usage:
+            print("\nexport MQSUB_ENSURE_NCPUS={}".format(args.cpus), file=outfile)
+            print("export MQSUB_ENSURE_THRESHOLD={}".format(args.ensure_cpu_usage_threshold), file=outfile)
+            print("export MQSUB_ENSURE_INTERVAL={}".format(args.ensure_cpu_usage_interval), file=outfile)
+            print(ENSURE_CPU_USAGE_SHELL_SNIPPET, file=outfile)
         if args.command_file and (args.chunk_num or args.chunk_size):
             print("\nNUM_FAILED=0\n", file=outfile)
         if args.command_file and (args.chunk_num or args.chunk_size):
@@ -419,6 +522,9 @@ Example usage:
     parser.add_argument('--run-tmp-dir', dest='run_tmp_dir',action='store_true', help='Executes your command(s) on the local SSD ($TMPDIR/mqsub_processing) of a node. IMPORTANT: Use absolute paths for your input files, and a relative path for your output.')
     parser.add_argument('--depend', nargs='+', help='Space separated list of ids for jobs this job should depend on.')
     parser.add_argument('--segregated-log-files', action='store_true', help='Put log files in ~/qsub_logs/<date>/<directory> instead of the current working directory.')
+    parser.add_argument('--ensure-cpu-usage', action='store_true', help='While the job runs, check that it is using at least --ensure-cpu-usage-threshold %% of its allocated CPUs over each --ensure-cpu-usage-interval window. If not, qdel the job and exit with status {}.'.format(ENSURE_CPU_USAGE_EXIT_STATUS))
+    parser.add_argument('--ensure-cpu-usage-threshold', type=float, default=50.0, help='Minimum percentage of allocated CPU time that resources_used.cput must accumulate during each check window when --ensure-cpu-usage is set [default: 50.0]')
+    parser.add_argument('--ensure-cpu-usage-interval', type=int, default=1800, help='Length of each --ensure-cpu-usage check window in seconds [default: 1800 (30 min)]')
     parser.add_argument('command',nargs='*',help='command to be run')
     parser.epilog = '''
 ----------------------------------------------------------------------------------------------------------

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,0 +1,379 @@
+version: 6
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages: {}
+  dev:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  md5: a9f577daf3de00bca7c3c76c0ecbd1de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgomp >=7.5.0
+  constrains:
+  - openmp_impl <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28948
+  timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  sha256: 0b75d45f0bba3e95dc693336fa51f40ea28c980131fec438afb7ce6118ed05f6
+  md5: d2ffd7602c02f2b316fd921d39876885
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 260182
+  timestamp: 1771350215188
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
+  sha256: c9dbcc8039a52023660d6d1bbf87594a93dd69c6ac5a2a44323af2c92976728d
+  md5: e18ad67cf881dcadee8b8d9e2f8e5f73
+  depends:
+  - __unix
+  license: ISC
+  size: 131039
+  timestamp: 1776865545798
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+  sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+  md5: 962b9857ee8e7018c22f2776ffa0b2d7
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27011
+  timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+  sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
+  md5: 8e662bd460bda79b1ea39194e3c4c9ab
+  depends:
+  - python >=3.10
+  - typing_extensions >=4.6.0
+  license: MIT and PSF-2.0
+  size: 21333
+  timestamp: 1763918099466
+- conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+  sha256: e1a9e3b1c8fe62dc3932a616c284b5d8cbe3124bbfbedcf4ce5c828cb166ee19
+  md5: 9614359868482abba1bd15ce465e3c42
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 13387
+  timestamp: 1760831448842
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  sha256: 3d584956604909ff5df353767f3a2a2f60e07d070b328d109f30ac40cd62df6c
+  md5: 18335a698559cdbcd86150a48bf54ba6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - binutils_impl_linux-64 2.45.1
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 728002
+  timestamp: 1774197446916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.0-hecca717_0.conda
+  sha256: ea33c40977ea7a2c3658c522230058395bc2ee0d89d99f0711390b6a1ee80d12
+  md5: a3b390520c563d78cc58974de95a03e5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.0.*
+  license: MIT
+  license_family: MIT
+  size: 77241
+  timestamp: 1777846112704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+  sha256: 31f19b6a88ce40ebc0d5a992c131f57d919f73c0b92cd1617a5bec83f6e961e6
+  md5: a360c33a5abe61c07959e449fa1453eb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  size: 58592
+  timestamp: 1769456073053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+  md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 1041084
+  timestamp: 1778269013026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  md5: faac990cb7aedc7f3a2224f2c9b0c26c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 603817
+  timestamp: 1778268942614
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.3.*
+  license: 0BSD
+  size: 113478
+  timestamp: 1775825492909
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+  sha256: fe171ed5cf5959993d43ff72de7596e8ac2853e9021dec0344e583734f1e0843
+  md5: 2c21e66f50753a083cbe6b80f38268fa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 92400
+  timestamp: 1769482286018
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.1-h0c1763c_0.conda
+  sha256: 54cdcd3214313b62c2a8ee277e6f42150d9b748264c1b70d958bf735e420ef8d
+  md5: 7dc38adcbf71e6b38748e919e16e0dce
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.2,<2.0a0
+  license: blessing
+  size: 954962
+  timestamp: 1777986471789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+  sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
+  md5: 38ffe67b78c9d4de527be8315e5ada2c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 40297
+  timestamp: 1775052476770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  size: 63629
+  timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  sha256: fc89f74bbe362fb29fa3c037697a89bec140b346a2469a90f7936d1d7ea4d8a3
+  md5: fc21868a1a5aacc937e7a18747acb8a5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: X11 AND BSD-3-Clause
+  size: 918956
+  timestamp: 1777422145199
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  size: 3167099
+  timestamp: 1775587756857
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
+  sha256: 3906abfb6511a3bb309e39b9b1b7bc38f50a723971de2395489fd1f379255890
+  md5: 4c06a92e74452cfa53623a81592e8934
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 91574
+  timestamp: 1777103621679
+- conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+  sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
+  md5: d7585b6550ad04c8c5e21097ada2888e
+  depends:
+  - python >=3.9
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25877
+  timestamp: 1764896838868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
+  md5: 16c18772b340887160c79a6acc022db0
+  depends:
+  - python >=3.10
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 893031
+  timestamp: 1774796815820
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+  md5: 6a991452eadf2771952f39d43615bb3e
+  depends:
+  - colorama >=0.4
+  - pygments >=2.7.2
+  - python >=3.10
+  - iniconfig >=1.0.1
+  - packaging >=22
+  - pluggy >=1.5,<2
+  - tomli >=1
+  - exceptiongroup >=1
+  - python
+  constrains:
+  - pytest-faulthandler >=2
+  license: MIT
+  license_family: MIT
+  size: 299984
+  timestamp: 1775644472530
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.4-habeac84_100_cp314.conda
+  build_number: 100
+  sha256: dec247c5badc811baa34d6085df9d0465535883cf745e22e8d79092ad54a3a7b
+  md5: a443f87920815d41bfe611296e507995
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.7.5,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.2,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.52.0,<4.0a0
+  - libuuid >=2.42,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  size: 36705460
+  timestamp: 1775614357822
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+  build_number: 8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
+  constrains:
+  - python 3.14.* *_cp314
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6989
+  timestamp: 1752805904792
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+  sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
+  md5: d7d95fc8287ea7bf33e0e7116d2b95ec
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - ncurses >=6.5,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 345073
+  timestamp: 1765813471974
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+  sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
+  md5: cffd3bdd58090148f4cfcd831f4b26ab
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: TCL
+  license_family: BSD
+  size: 3301196
+  timestamp: 1769460227866
+- conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  sha256: 91cafdb64268e43e0e10d30bd1bef5af392e69f00edd34dfaf909f69ab2da6bd
+  md5: b5325cf06a000c5b14970462ff5e4d58
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 21561
+  timestamp: 1774492402955
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+  sha256: 032271135bca55aeb156cee361c81350c6f3fb203f57d024d7e5a1fc9ef18731
+  md5: 0caa1af407ecff61170c9437a808404d
+  depends:
+  - python >=3.10
+  - python
+  license: PSF-2.0
+  license_family: PSF
+  size: 51692
+  timestamp: 1756220668932
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  sha256: 1d30098909076af33a35017eed6f2953af1c769e273a0626a04722ac4acaba3c
+  md5: ad659d0a2b3e47e38d829aa8cad2d610
+  license: LicenseRef-Public-Domain
+  size: 119135
+  timestamp: 1767016325805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  sha256: 68f0206ca6e98fea941e5717cec780ed2873ffabc0e1ed34428c061e2c6268c7
+  md5: 4a13eeac0b5c8e5b8ab496e6c4ddd829
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 601375
+  timestamp: 1764777111296

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,18 @@
+[workspace]
+authors = ["Ben Woodcroft <benjwoodcroft@gmail.com>"]
+channels = ["conda-forge", "bioconda"]
+name = "hpc_scripts"
+platforms = ["linux-64"]
+version = "0.1.0"
+
+[tasks]
+test = "pytest tests"
+
+[dependencies]
+
+[feature.dev.dependencies]
+python = "*"
+pytest = "*"
+
+[environments]
+dev = ["dev"]

--- a/tests/test_mqsub_ensure_cpu_usage.py
+++ b/tests/test_mqsub_ensure_cpu_usage.py
@@ -1,0 +1,92 @@
+"""Integration tests for mqsub --ensure-cpu-usage.
+
+Submits real PBS jobs via mqsub and waits for them to complete, so each test
+takes several minutes plus queue time. Skipped automatically when qsub is not
+available on PATH.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+MQSUB = REPO / "bin" / "mqsub"
+
+INTERVAL_SECONDS = 120
+THRESHOLD_PERCENT = 50
+JOB_TIMEOUT_SECONDS = 30 * 60
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("qsub") is None,
+    reason="qsub not available; --ensure-cpu-usage integration tests need a PBS queue",
+)
+
+
+@pytest.fixture
+def shared_cwd():
+    # PBS writes the job's .o/.e files to the submission cwd on the compute
+    # node; if cwd is /tmp it won't be visible to the head node. Use $HOME.
+    base = Path.home() / ".mqsub_pytest"
+    base.mkdir(exist_ok=True)
+    path = Path(tempfile.mkdtemp(dir=str(base)))
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def _run_mqsub(extra_args, cwd, stdin=None):
+    cmd = [
+        sys.executable, str(MQSUB),
+        "-t", "1",
+        "--hours", "1",
+        "--no-email",
+        "--no-executable-check",
+        "--ensure-cpu-usage",
+        "--ensure-cpu-usage-interval={}".format(INTERVAL_SECONDS),
+        "--ensure-cpu-usage-threshold={}".format(THRESHOLD_PERCENT),
+    ] + list(extra_args)
+    return subprocess.run(
+        cmd,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        timeout=JOB_TIMEOUT_SECONDS,
+    )
+
+
+def test_ensure_cpu_usage_passes_when_cpu_busy(shared_cwd):
+    # Busy-loop in bash for one interval plus a margin, so the monitor fires
+    # exactly one check (~100% utilisation) and the job then exits 0.
+    busy_seconds = INTERVAL_SECONDS + 60
+    script = (
+        "#!/bin/bash\n"
+        "end=$((SECONDS + {}))\n".format(busy_seconds) +
+        "while [ $SECONDS -lt $end ]; do :; done\n"
+        "exit 0\n"
+    )
+    result = _run_mqsub(["--script", "-"], cwd=shared_cwd, stdin=script)
+    assert result.returncode == 0, (
+        "expected exit 0, got {}\nstdout:\n{}\nstderr:\n{}".format(
+            result.returncode, result.stdout, result.stderr
+        )
+    )
+    assert "--ensure-cpu-usage check failed" not in result.stderr
+
+
+def test_ensure_cpu_usage_kills_idle_job(shared_cwd):
+    # Sleep well past the first check window; the monitor should cancel the job
+    # at the first interval boundary and the wrapper should exit 151.
+    idle_seconds = INTERVAL_SECONDS * 3
+    result = _run_mqsub(["--", "sleep", str(idle_seconds)], cwd=shared_cwd)
+    assert result.returncode == 151, (
+        "expected exit 151, got {}\nstdout:\n{}\nstderr:\n{}".format(
+            result.returncode, result.stdout, result.stderr
+        )
+    )
+    assert "--ensure-cpu-usage check failed" in result.stderr


### PR DESCRIPTION
Submitted PBS scripts now optionally include a background Python monitor that polls resources_used.cput / walltime each interval (default 30 min). If per-window utilisation falls below the threshold (default 50%) of the allocated CPUs, the monitor cancels the job and the wrapper exits 151. Threshold and interval are tunable for testing.

Also adds a pixi dev environment with pytest and an integration test that submits real PBS jobs to exercise the pass and fail paths.