### PR TITLE
Make snakemake aqua profile work inside mqyolo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ boxed into the same sandbox:
 - `bin/mqsandbox` — runs an arbitrary command inside the restricted container
 - `bin/_sandbox_common.bash` — shared bind/env construction (sourced by the two above)
 - `bin/mqsub-broker` — host-side broker; runs allowlisted commands, forces `--sandbox`
-- `bin/mqbroker-stub` — container-side stub (symlinked as mqsub/mqstat/mqwait/mqdel)
+- `bin/mqbroker-stub` — container-side stub (symlinked as mqsub/mqstat/mqwait/mqdel/qstat/qdel)
 - `bin/mqsub` — `--sandbox` / `--sandbox-rw-paths` wrap the job in `mqsandbox`
 
 **Whenever you change any of the files above, run the test suite and make sure it
@@ -33,6 +33,10 @@ Key invariants the tests guard (keep them true):
 - Jobs submitted from inside the container are always `--sandbox`ed and inherit
   mqyolo's fixed `--rw-paths`; the container cannot change them (`--no-sandbox` and
   `--sandbox-rw-paths` from the container are rejected).
+- `snakemake --profile aqua` works inside the container: its cluster helpers
+  (`snakemake_mqsub`, `snakemake_mqstat`) are staged onto PATH as repo tools, and
+  the `qstat`/`qdel` they (and snakemake's cluster-cancel) rely on are proxied to
+  the host via the broker alongside mqsub/mqstat/mqwait/mqdel.
 - The broker is tied to the mqyolo session and self-terminates when the mqyolo PID
   disappears.
 - The in-container AI tool is told where heavy/long/high-RAM commands should run —

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -329,7 +329,11 @@ sandbox_home_dotfiles() {
 # and runs the version that ships with mqyolo, independent of any separately
 # deployed copy under /work/microbiome/sw.
 # ---------------------------------------------------------------------------
-SANDBOX_REPO_TOOLS=(pixi_cmr_init.py)
+# snakemake_mqsub / snakemake_mqstat are the cluster submit/status helpers used by
+# the snakemake "aqua" (and mqsub/lyra) profiles. Staging them here puts them on
+# PATH inside the container so `snakemake --profile aqua` works there, running the
+# version that ships with mqyolo (its `mqsub`/`qstat` calls go through the broker).
+SANDBOX_REPO_TOOLS=(pixi_cmr_init.py snakemake_mqsub snakemake_mqstat)
 
 # ---------------------------------------------------------------------------
 # sandbox_stage_repo_tools TOOLS_DIR SCRIPT_DIR

--- a/bin/mqbroker-stub
+++ b/bin/mqbroker-stub
@@ -1,10 +1,10 @@
 #!/bin/bash
 # mqbroker-stub - container-side stub that forwards a command to the host broker.
 #
-# Symlinked (by mqyolo) as mqsub, mqstat, mqwait and mqdel inside a shim dir that
-# is prepended to PATH in the container. When the AI tool runs e.g. `mqsub ...`,
-# this stub runs instead of the real (python3.9 + qsub) mqsub, which cannot work
-# inside the container. It serialises the command name, argv, CWD and any stdin
+# Symlinked (by mqyolo) as mqsub, mqstat, mqwait, mqdel, qstat and qdel inside a
+# shim dir that is prepended to PATH in the container. When the AI tool runs e.g.
+# `mqsub ...`, this stub runs instead of the real (python3.9 + qsub) mqsub, which
+# cannot work inside the container. It serialises the command name, argv, CWD and any stdin
 # into a request directory in the bind-mounted spool, waits for the host
 # mqsub-broker to run the real command, then replays its stdout/stderr/exit code.
 #

--- a/bin/mqsub-broker
+++ b/bin/mqsub-broker
@@ -5,9 +5,9 @@
 # qsub and the python3.9 that mqsub needs do not exist inside the container, and
 # an Apptainer container cannot spawn processes on the host. So mqyolo starts one
 # of these brokers per session in the host namespace. The container-side stubs
-# (mqbroker-stub, symlinked as mqsub/mqstat/mqwait/mqdel) drop request files into
-# a spool directory that is bind-mounted into the container; the broker runs the
-# real command on the host and writes the result back.
+# (mqbroker-stub, symlinked as mqsub/mqstat/mqwait/mqdel/qstat/qdel) drop request
+# files into a spool directory that is bind-mounted into the container; the broker
+# runs the real command on the host and writes the result back.
 #
 # Resource use is deliberately tiny: the broker blocks in inotifywait (zero CPU
 # while idle) and only wakes on a request or every --watch-interval seconds to
@@ -49,8 +49,11 @@ REQ_DIR="${SPOOL}/req"
 mkdir -p "$REQ_DIR"
 
 # Commands the broker is willing to run on the host. mqsub is special-cased to
-# force --sandbox so every job submitted from the container is boxed in.
-ALLOWED="mqsub mqstat mqwait mqdel qstat"
+# force --sandbox so every job submitted from the container is boxed in. qstat and
+# qdel are needed by `snakemake --profile aqua` (its cluster-status command
+# snakemake_mqstat shells out to `qstat`, and its cluster-cancel command is
+# `qdel`); PBS enforces that a user can only qdel their own jobs.
+ALLOWED="mqsub mqstat mqwait mqdel qstat qdel"
 
 log() { [[ "$DEBUG" -eq 1 ]] && echo "mqsub-broker: $*" >&2 || true; }
 

--- a/bin/mqyolo
+++ b/bin/mqyolo
@@ -225,8 +225,9 @@ MQSUB FROM INSIDE THE CONTAINER
   qsub and the python3.9 mqsub depends on do not exist inside the container, so
   mqsub cannot run there directly. Instead, mqyolo starts a lightweight broker
   on the host for the duration of the session (one broker per mqyolo session).
-  Inside the container, mqsub/mqstat/mqwait/mqdel are thin stubs that forward the
-  request to the broker, which runs the real command on the host. mqsub jobs are
+  Inside the container, mqsub/mqstat/mqwait/mqdel (and qstat/qdel, so
+  `snakemake --profile aqua` works) are thin stubs that forward the request to the
+  broker, which runs the real command on the host. mqsub jobs are
   automatically submitted with --sandbox, so each job runs on its compute node
   inside the SAME restricted container (only its working directory plus mqyolo's
   --rw-paths writable, and the same deny-list with mqyolo's --ro-paths re-exposed
@@ -368,8 +369,11 @@ if [[ "$NO_BROKER" -eq 0 && -x "${SCRIPT_DIR}/mqsub-broker" && -x "${SCRIPT_DIR}
 
     # Symlink the stub as each proxied command. The target must be valid INSIDE
     # the container, so use the canonical path (bound ro under /home|/mnt|/work).
+    # qstat/qdel are proxied too so `snakemake --profile aqua` works in the
+    # container: its cluster-status helper (snakemake_mqstat) calls `qstat` and its
+    # cluster-cancel command is `qdel`, neither of which exists inside the sandbox.
     _stub_real="$(readlink -f "${SCRIPT_DIR}/mqbroker-stub")"
-    for _c in mqsub mqstat mqwait mqdel; do
+    for _c in mqsub mqstat mqwait mqdel qstat qdel; do
         ln -sf "$_stub_real" "${SHIM_DIR}/${_c}"
     done
     unset _c _stub_real

--- a/tests/test_mqyolo_sandbox.py
+++ b/tests/test_mqyolo_sandbox.py
@@ -302,6 +302,28 @@ def test_broker_rejects_non_allowlisted_command():
         assert "not permitted" in out
 
 
+# `snakemake --profile aqua` drives the queue from inside the container via
+# snakemake_mqstat (which shells out to `qstat`) and a `qdel` cluster-cancel, so
+# the broker must allow both (mqsub/mqstat/mqwait/mqdel cover the rest).
+@pytest.mark.skipif(shutil.which("qstat") is None, reason="qstat not on PATH")
+def test_broker_allows_qstat():
+    with running_broker() as (spool, shim, *_):
+        qstat = _stub_as(shim, "qstat")
+        # A bogus job id: real qstat runs and errors, but the broker must NOT
+        # reject it as non-allowlisted (which would be rc 126 / "not permitted").
+        rc, out = _run_stub(qstat, spool, "-x", "-f", "0.nonexistent-mqyolo-test")
+        assert "not permitted" not in out, out
+        assert not (rc == 126 and "not permitted" in out)
+
+
+@pytest.mark.skipif(shutil.which("qdel") is None, reason="qdel not on PATH")
+def test_broker_allows_qdel():
+    with running_broker() as (spool, shim, *_):
+        qdel = _stub_as(shim, "qdel")
+        rc, out = _run_stub(qdel, spool, "0.nonexistent-mqyolo-test")
+        assert "not permitted" not in out, out
+
+
 def test_broker_propagates_nonzero_exit_and_stderr():
     with running_broker() as (spool, shim, *_):
         mqsub = _stub_as(shim, "mqsub")
@@ -393,6 +415,27 @@ def test_stage_repo_tools_symlinks_pixi_cmr_init(tmp_path):
     assert p.returncode == 0, p.stderr
     # The staged symlink points at the repo's real pixi_cmr_init.py.
     assert p.stdout.strip() == os.path.realpath(str(PIXI_CMR_INIT)), p.stdout
+
+
+def test_snakemake_cluster_tools_present_in_repo():
+    # The aqua/mqsub/lyra snakemake profiles call these; mqyolo stages them onto
+    # PATH inside the container, so they must exist in the repo bin.
+    assert (BIN / "snakemake_mqsub").exists(), "snakemake_mqsub missing from repo bin"
+    assert (BIN / "snakemake_mqstat").exists(), "snakemake_mqstat missing from repo bin"
+
+
+@pytest.mark.parametrize("tool", ["snakemake_mqsub", "snakemake_mqstat"])
+def test_stage_repo_tools_symlinks_snakemake_cluster_tools(tmp_path, tool):
+    # So `snakemake --profile aqua` finds the shipped helpers inside the container.
+    tools = tmp_path / "tools"
+    script = (
+        "source %s; sandbox_stage_repo_tools %s %s; readlink -f %s/%s"
+        % (SANDBOX_LIB, shlex.quote(str(tools)), shlex.quote(str(BIN)),
+           shlex.quote(str(tools)), shlex.quote(tool))
+    )
+    p = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert p.returncode == 0, p.stderr
+    assert p.stdout.strip() == os.path.realpath(str(BIN / tool)), p.stdout
 
 
 def test_pixi_cmr_init_resolves_on_path_via_shim_bashrc(tmp_path):


### PR DESCRIPTION
Running `snakemake --profile aqua` (and the mqsub/lyra profiles) inside the
mqyolo container previously broke at the cluster-status and cluster-cancel
steps: snakemake_mqstat shells out to `qstat`, and the profiles' cluster-cancel
command is `qdel`, neither of which exists inside the sandbox (no qsub/PBS
client there). `qstat` was already on the broker allowlist but had no
container-side stub.

- mqsub-broker: add `qdel` to the allowlist (qstat was already allowed); PBS
  still restricts a user to deleting their own jobs.
- mqyolo: symlink the broker stub as `qstat` and `qdel` too, so those calls are
  proxied to the host like mqsub/mqstat/mqwait/mqdel.
- _sandbox_common.bash: stage snakemake_mqsub / snakemake_mqstat as repo tools
  so the in-container snakemake finds the version shipping with mqyolo (their
  mqsub/qstat calls go through the broker).
- Update stub/broker/help/CLAUDE docs and add tests for the new behaviour.