### PR TITLE
fix command-files with mqsub

### DIFF
--- a/bin/mqsub
+++ b/bin/mqsub
@@ -566,6 +566,8 @@ Further information can also be found in the CMR Compute Notes -  https://tinyur
     SCRIPT = 'script'
     COMMAND = 'command'
 
+    content_type = COMMAND
+
     if args.script:
         content_type = SCRIPT
         if len(args.command) != 0:


### PR DESCRIPTION
Fixes a NameError when running mqsub with --command-file but no inline command. The chunked command-file branch never sets content_type