### PR TITLE
singularity: add man-db to container image

### DIFF
--- a/singularity/ai_tool.def
+++ b/singularity/ai_tool.def
@@ -13,8 +13,9 @@ From: node:24
     #   rsync: commonly invoked for file transfers inside sessions.
     #   curl:  needed for Codex CLI installation script.
     #   gawk:  needed for Codex CLI installation script.
+    #   man-db: provides the `man` command for reading manual pages.
     apt-get update
-    apt-get install -y --no-install-recommends time less rsync curl ca-certificates gawk jq
+    apt-get install -y --no-install-recommends time less rsync curl ca-certificates gawk jq man-db
     rm -rf /var/lib/apt/lists/*
 
     # Install Claude Code, OpenAI Codex CLI, and GitHub Copilot CLI


### PR DESCRIPTION
Installs the `man` command so manual pages are available inside the
mqyolo sandbox.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VpBbpsyhdPcYS9oxkWfZHA