### PR TITLE
mqlint: detect effective pixi cache dir and suggest config fix + deletion

### DIFF
--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -418,30 +418,59 @@ sandbox_build_binds() {
         esac
     done
 
-    if command -v pixi &>/dev/null; then
-        # Effective root cache dir. `|| true` keeps a nonzero `pixi info` (broken
-        # config) from tripping pipefail and aborting the launch.
-        local _pixi_info_json _pixi_config_json
+    # Ask pixi for the effective root cache dir and any per-kind cache config
+    # paths. We parse the JSON with python3 (always present alongside pixi/conda
+    # here; jq may not be) inside a single helper that also filters to real path
+    # values — the `cache` table also holds non-path settings such as
+    # `netfs-redirect = "auto"` which must not become bind targets — and expands
+    # a leading ~ / env vars so `realpath` below never treats a stored "~" as a
+    # relative path. Every probe is non-fatal (`|| true`, guarded from pipefail)
+    # so a broken pixi config never aborts the sandbox launch under the caller's
+    # `set -euo pipefail`.
+    if command -v pixi &>/dev/null && command -v python3 &>/dev/null; then
+        local _pixi_info_json _pixi_config_json _kind_path
         _pixi_info_json="$(pixi info --json 2>/dev/null || true)"
-        if [[ -n "$_pixi_info_json" ]]; then
-            local _pixi_effective_cache
-            _pixi_effective_cache="$(printf '%s' "$_pixi_info_json" \
-                | jq -r '.cache_dir // empty' 2>/dev/null || true)"
-            [[ -n "$_pixi_effective_cache" ]] && _pixi_cache_candidates+=("$_pixi_effective_cache")
-        fi
-        # Per-kind cache config path values (string values under the `cache` table
-        # other than `root`, which is already covered by the effective cache
-        # above). Restrict to actual paths (leading / or ~): the cache table also
-        # holds non-path settings such as `netfs-redirect = "auto"` which must not
-        # be turned into a bind target (mqlint applies the same filter).
         _pixi_config_json="$(pixi config list --json 2>/dev/null || true)"
-        if [[ -n "$_pixi_config_json" ]]; then
-            local _kind_path
-            while IFS= read -r _kind_path; do
-                [[ -n "$_kind_path" ]] && _pixi_cache_candidates+=("$_kind_path")
-            done < <(printf '%s' "$_pixi_config_json" \
-                | jq -r '(.cache // {}) | to_entries[] | select(.key != "root" and (.value | type == "string") and (.value | test("^(/|~)"))) | .value' 2>/dev/null || true)
-        fi
+        while IFS= read -r _kind_path; do
+            [[ -n "$_kind_path" ]] && _pixi_cache_candidates+=("$_kind_path")
+        done < <(
+            PIXI_INFO_JSON="$_pixi_info_json" PIXI_CONFIG_JSON="$_pixi_config_json" \
+            python3 - <<'PY' 2>/dev/null || true
+import json, os
+
+def expand(p):
+    return os.path.expanduser(os.path.expandvars(p))
+
+out = []
+info = os.environ.get("PIXI_INFO_JSON") or ""
+cfg = os.environ.get("PIXI_CONFIG_JSON") or ""
+
+try:
+    d = json.loads(info) if info.strip() else {}
+    root = d.get("cache_dir")
+    if isinstance(root, str) and root:
+        out.append(expand(root))
+except Exception:
+    pass
+
+try:
+    c = json.loads(cfg) if cfg.strip() else {}
+    cache = c.get("cache") if isinstance(c, dict) else None
+    if isinstance(cache, dict):
+        for key, val in cache.items():
+            if key == "root" or not isinstance(val, str):
+                continue
+            # Only real path values (leading / or ~), not settings like
+            # netfs-redirect = "auto".
+            if val.startswith("/") or val.startswith("~"):
+                out.append(expand(val))
+except Exception:
+    pass
+
+for p in out:
+    print(p)
+PY
+        )
     fi
 
     for _pixi_cache in "${_pixi_cache_candidates[@]}"; do

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -473,9 +473,18 @@ PY
         )
     fi
 
+    # Only rw-bind caches that actually land on the read-only shared trees
+    # (/pkg/cmr, /mnt/weka). A cache elsewhere (e.g. pixi's default
+    # ~/.cache/rattler when nothing is configured) is already writable, so
+    # binding it is pointless — and worse, mkdir'ing/binding the default would
+    # *create* the off-filesystem home cache that mqlint tells users to avoid.
     for _pixi_cache in "${_pixi_cache_candidates[@]}"; do
         [[ -n "$_pixi_cache" ]] || continue
         _pixi_cache_real="$(realpath "$_pixi_cache" 2>/dev/null || echo "$_pixi_cache")"
+        case "$_pixi_cache_real" in
+            /pkg/cmr/*|/mnt/weka/*) ;;   # on a read-only shared tree: bind it rw
+            *) continue ;;               # already writable / off-tree: leave alone
+        esac
         mkdir -p "$_pixi_cache_real" 2>/dev/null || true
         [[ -d "$_pixi_cache_real" ]] && BIND_ARGS+=(--bind "${_pixi_cache_real}:${_pixi_cache_real}:rw")
     done

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -427,10 +427,22 @@ sandbox_build_binds() {
     # relative path. Every probe is non-fatal (`|| true`, guarded from pipefail)
     # so a broken pixi config never aborts the sandbox launch under the caller's
     # `set -euo pipefail`.
-    if command -v pixi &>/dev/null && command -v python3 &>/dev/null; then
+    # Resolve pixi even when the deployed bin/ is not on the host PATH: mqyolo/
+    # mqsandbox run by absolute path (or in a batch job) still ship pixi next to
+    # the sandbox scripts (SCRIPT_DIR/pixi, staged by sandbox_stage_repo_tools).
+    # Prefer that, then fall back to PATH.
+    local _pixi_bin=""
+    local _script_dir="${SANDBOX_SCRIPT_DIR:-${SCRIPT_DIR:-}}"
+    if [[ -n "$_script_dir" && -x "${_script_dir}/pixi" ]]; then
+        _pixi_bin="${_script_dir}/pixi"
+    elif command -v pixi &>/dev/null; then
+        _pixi_bin="pixi"
+    fi
+
+    if [[ -n "$_pixi_bin" ]] && command -v python3 &>/dev/null; then
         local _pixi_info_json _pixi_config_json _kind_path
-        _pixi_info_json="$(pixi info --json 2>/dev/null || true)"
-        _pixi_config_json="$(pixi config list --json 2>/dev/null || true)"
+        _pixi_info_json="$("$_pixi_bin" info --json 2>/dev/null || true)"
+        _pixi_config_json="$("$_pixi_bin" config list --json 2>/dev/null || true)"
         while IFS= read -r _kind_path; do
             [[ -n "$_kind_path" ]] && _pixi_cache_candidates+=("$_kind_path")
         done < <(

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -441,8 +441,13 @@ sandbox_build_binds() {
 
     if [[ -n "$_pixi_bin" ]] && command -v python3 &>/dev/null; then
         local _pixi_info_json _pixi_config_json _kind_path
-        _pixi_info_json="$("$_pixi_bin" info --json 2>/dev/null || true)"
-        _pixi_config_json="$("$_pixi_bin" config list --json 2>/dev/null || true)"
+        # Probe from the sandbox's target CWD, not the launcher's process cwd:
+        # mqsandbox --cwd (and the container's --pwd) may point elsewhere, and a
+        # project-local <CWD>/.pixi/config.toml only takes effect from that dir.
+        # Run in a subshell so the function's own cwd is unchanged; if the cd
+        # fails, fall back to probing in place.
+        _pixi_info_json="$( { cd "$cwd" 2>/dev/null; "$_pixi_bin" info --json; } 2>/dev/null || true)"
+        _pixi_config_json="$( { cd "$cwd" 2>/dev/null; "$_pixi_bin" config list --json; } 2>/dev/null || true)"
         while IFS= read -r _kind_path; do
             [[ -n "$_kind_path" ]] && _pixi_cache_candidates+=("$_kind_path")
         done < <(

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -409,11 +409,15 @@ sandbox_build_binds() {
     local _pixi_cache _pixi_cache_real
     local -a _pixi_cache_candidates=("${PIXI_CACHE_DIR:-}" "${RATTLER_CACHE_DIR:-}")
 
-    # Per-kind cache env vars (e.g. PIXI_CACHE_CONDA_PACKAGES_DIR).
+    # Per-kind cache env vars (e.g. PIXI_CACHE_CONDA_PACKAGES_DIR). Only the
+    # PIXI_CACHE_<KIND>_DIR form is a documented per-kind override; there is no
+    # RATTLER_ per-kind alias (RATTLER_CACHE_DIR is only the root alias, already
+    # a candidate above), so scanning RATTLER_CACHE_*_DIR would bind dirs pixi
+    # never uses.
     local _v
-    for _v in "${!PIXI_CACHE_@}" "${!RATTLER_CACHE_@}"; do
+    for _v in "${!PIXI_CACHE_@}"; do
         case "$_v" in
-            PIXI_CACHE_DIR|RATTLER_CACHE_DIR) continue ;;  # roots, already added
+            PIXI_CACHE_DIR) continue ;;   # root, already added
             *_DIR) _pixi_cache_candidates+=("${!_v}") ;;
         esac
     done

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -399,19 +399,48 @@ sandbox_build_binds() {
     # (sandbox_build_env); inside the container it resolves through the ro-bound
     # parent symlink onto this rw bind.
     #
-    # The effective cache dir may come from PIXI_CACHE_DIR / RATTLER_CACHE_DIR OR
-    # from the `cache.root` config key (which mqlint may steer users towards), so
-    # ask pixi for the resolved value in addition to the env vars. Without this,
-    # a config-only cache.root under /pkg/cmr would stay read-only in the sandbox.
+    # The effective cache dir may come from PIXI_CACHE_DIR / RATTLER_CACHE_DIR, the
+    # `cache.root` config key (which mqlint may steer users towards), or a per-kind
+    # override (cache.<kind> config / PIXI_CACHE_*_DIR env vars). Any of these can
+    # land under /pkg/cmr, which is bound READ-ONLY above, so collect them all and
+    # rw-bind each. Every pixi probe is made non-fatal (|| true, and guarded from
+    # pipefail) so a broken pixi config never aborts the sandbox launch under the
+    # caller's `set -euo pipefail`.
     local _pixi_cache _pixi_cache_real
     local -a _pixi_cache_candidates=("${PIXI_CACHE_DIR:-}" "${RATTLER_CACHE_DIR:-}")
+
+    # Per-kind cache env vars (e.g. PIXI_CACHE_CONDA_PACKAGES_DIR).
+    local _v
+    for _v in "${!PIXI_CACHE_@}" "${!RATTLER_CACHE_@}"; do
+        case "$_v" in
+            PIXI_CACHE_DIR|RATTLER_CACHE_DIR) continue ;;  # roots, already added
+            *_DIR) _pixi_cache_candidates+=("${!_v}") ;;
+        esac
+    done
+
     if command -v pixi &>/dev/null; then
-        local _pixi_effective_cache
-        _pixi_effective_cache="$(pixi info --json 2>/dev/null \
-            | sed -n 's/.*"cache_dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
-            | head -n1)"
-        [[ -n "$_pixi_effective_cache" ]] && _pixi_cache_candidates+=("$_pixi_effective_cache")
+        # Effective root cache dir. `|| true` keeps a nonzero `pixi info` (broken
+        # config) from tripping pipefail and aborting the launch.
+        local _pixi_info_json _pixi_config_json
+        _pixi_info_json="$(pixi info --json 2>/dev/null || true)"
+        if [[ -n "$_pixi_info_json" ]]; then
+            local _pixi_effective_cache
+            _pixi_effective_cache="$(printf '%s' "$_pixi_info_json" \
+                | jq -r '.cache_dir // empty' 2>/dev/null || true)"
+            [[ -n "$_pixi_effective_cache" ]] && _pixi_cache_candidates+=("$_pixi_effective_cache")
+        fi
+        # Per-kind cache config values (any string under the `cache` table other
+        # than `root`, which is already covered by the effective cache above).
+        _pixi_config_json="$(pixi config list --json 2>/dev/null || true)"
+        if [[ -n "$_pixi_config_json" ]]; then
+            local _kind_path
+            while IFS= read -r _kind_path; do
+                [[ -n "$_kind_path" ]] && _pixi_cache_candidates+=("$_kind_path")
+            done < <(printf '%s' "$_pixi_config_json" \
+                | jq -r '(.cache // {}) | to_entries[] | select(.key != "root" and (.value | type == "string")) | .value' 2>/dev/null || true)
+        fi
     fi
+
     for _pixi_cache in "${_pixi_cache_candidates[@]}"; do
         [[ -n "$_pixi_cache" ]] || continue
         _pixi_cache_real="$(realpath "$_pixi_cache" 2>/dev/null || echo "$_pixi_cache")"

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -392,14 +392,27 @@ sandbox_build_binds() {
     [[ -d "$_pixi_dirs" ]] && BIND_ARGS+=(--bind "${_pixi_dirs}:${_pixi_dirs}:rw")
 
     # --- Writable pixi/rattler cache dir ---
-    # PIXI_CACHE_DIR / RATTLER_CACHE_DIR commonly point into shared storage on
-    # /pkg/cmr or /mnt/weka (see mqlint), which is bound READ-ONLY above, so pixi
-    # can't populate its cache. Bind the cache rw at its canonical path so
-    # `pixi install` / env regeneration works. The env var is forwarded as the
-    # original logical path (sandbox_build_env); inside the container it resolves
-    # through the ro-bound parent symlink onto this rw bind.
+    # The pixi cache commonly points into shared storage on /pkg/cmr or /mnt/weka
+    # (see mqlint), which is bound READ-ONLY above, so pixi can't populate its
+    # cache. Bind the cache rw at its canonical path so `pixi install` / env
+    # regeneration works. The path is forwarded as the original logical path
+    # (sandbox_build_env); inside the container it resolves through the ro-bound
+    # parent symlink onto this rw bind.
+    #
+    # The effective cache dir may come from PIXI_CACHE_DIR / RATTLER_CACHE_DIR OR
+    # from the `cache.root` config key (which mqlint may steer users towards), so
+    # ask pixi for the resolved value in addition to the env vars. Without this,
+    # a config-only cache.root under /pkg/cmr would stay read-only in the sandbox.
     local _pixi_cache _pixi_cache_real
-    for _pixi_cache in "${PIXI_CACHE_DIR:-}" "${RATTLER_CACHE_DIR:-}"; do
+    local -a _pixi_cache_candidates=("${PIXI_CACHE_DIR:-}" "${RATTLER_CACHE_DIR:-}")
+    if command -v pixi &>/dev/null; then
+        local _pixi_effective_cache
+        _pixi_effective_cache="$(pixi info --json 2>/dev/null \
+            | sed -n 's/.*"cache_dir"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+            | head -n1)"
+        [[ -n "$_pixi_effective_cache" ]] && _pixi_cache_candidates+=("$_pixi_effective_cache")
+    fi
+    for _pixi_cache in "${_pixi_cache_candidates[@]}"; do
         [[ -n "$_pixi_cache" ]] || continue
         _pixi_cache_real="$(realpath "$_pixi_cache" 2>/dev/null || echo "$_pixi_cache")"
         mkdir -p "$_pixi_cache_real" 2>/dev/null || true

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -429,15 +429,18 @@ sandbox_build_binds() {
                 | jq -r '.cache_dir // empty' 2>/dev/null || true)"
             [[ -n "$_pixi_effective_cache" ]] && _pixi_cache_candidates+=("$_pixi_effective_cache")
         fi
-        # Per-kind cache config values (any string under the `cache` table other
-        # than `root`, which is already covered by the effective cache above).
+        # Per-kind cache config path values (string values under the `cache` table
+        # other than `root`, which is already covered by the effective cache
+        # above). Restrict to actual paths (leading / or ~): the cache table also
+        # holds non-path settings such as `netfs-redirect = "auto"` which must not
+        # be turned into a bind target (mqlint applies the same filter).
         _pixi_config_json="$(pixi config list --json 2>/dev/null || true)"
         if [[ -n "$_pixi_config_json" ]]; then
             local _kind_path
             while IFS= read -r _kind_path; do
                 [[ -n "$_kind_path" ]] && _pixi_cache_candidates+=("$_kind_path")
             done < <(printf '%s' "$_pixi_config_json" \
-                | jq -r '(.cache // {}) | to_entries[] | select(.key != "root" and (.value | type == "string")) | .value' 2>/dev/null || true)
+                | jq -r '(.cache // {}) | to_entries[] | select(.key != "root" and (.value | type == "string") and (.value | test("^(/|~)"))) | .value' 2>/dev/null || true)
         fi
     fi
 

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -450,8 +450,11 @@ sandbox_build_binds() {
             python3 - <<'PY' 2>/dev/null || true
 import json, os
 
+# pixi's path syntax expands a leading ~ but treats environment-variable strings
+# ($VAR/${VAR}) LITERALLY, so we must only expanduser — never expandvars — or we
+# would bind a different directory than pixi actually writes to.
 def expand(p):
-    return os.path.expanduser(os.path.expandvars(p))
+    return os.path.expanduser(p)
 
 out = []
 info = os.environ.get("PIXI_INFO_JSON") or ""
@@ -460,8 +463,9 @@ cfg = os.environ.get("PIXI_CONFIG_JSON") or ""
 try:
     d = json.loads(info) if info.strip() else {}
     root = d.get("cache_dir")
+    # `cache_dir` from `pixi info` is already fully resolved by pixi.
     if isinstance(root, str) and root:
-        out.append(expand(root))
+        out.append(root)
 except Exception:
     pass
 

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -95,18 +95,28 @@ def is_within_weka(path):
 
 
 def looks_like_pixi_cache_dir(path):
-    """Heuristically decide whether `path` is a dedicated pixi/rattler cache dir.
+    """Heuristically decide whether `path` is a DEDICATED pixi/rattler cache dir.
 
-    Used to gate the destructive `rm -rf` deletion hint: we only suggest wiping
-    the whole path when its final component is a recognizable cache directory
-    name (so we never propose `rm -rf $HOME` or `rm -rf /tmp`).
+    Used to gate the destructive `rm -rf` deletion hint. We only accept a path
+    that clearly belongs to pixi/rattler, so we never propose `rm -rf` on a
+    broad root like $HOME, /tmp, or a shared cache root such as ~/.cache or
+    /var/cache (which hold unrelated application caches).
     """
     if not path:
         return False
-    basename = os.path.basename(str(path).rstrip('/')).lower()
-    # The final path component must itself name a cache dir, so we never propose
-    # rm -rf on a broad root like $HOME (basename = username) or /tmp.
-    return any(token in basename for token in ('cache', 'rattler', 'pixi'))
+    normalized = str(path).rstrip('/')
+    basename = os.path.basename(normalized).lower()
+    parent = os.path.basename(os.path.dirname(normalized)).lower()
+    # A leaf that names pixi/rattler is dedicated (e.g. …/pixi/cache's parent, or
+    # a dir literally called `rattler`).
+    if 'pixi' in basename or 'rattler' in basename:
+        return True
+    # pixi's default cache leaf is `cache`, but only treat it as dedicated when it
+    # sits under a rattler/pixi parent (…/rattler/cache). A bare `cache`/`.cache`
+    # root (e.g. ~/.cache, /var/cache) holds other tools' caches — never rm -rf.
+    if basename == 'cache':
+        return parent in ('rattler', 'pixi')
+    return False
 
 
 def parse_condarc_line(line):

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -10,7 +10,9 @@ This script checks a user's ~/.condarc file to ensure:
 It also checks pixi:
 4. The effective pixi cache dir (from `pixi info --json`, which accounts for
    PIXI_CACHE_DIR/RATTLER_CACHE_DIR and the `cache.root` config key) is within
-   /pkg/cmr or /mnt/weka. If not, it suggests symlinking ~/.cache/rattler onto
+   /pkg/cmr or /mnt/weka, and that no per-kind cache override (config
+   `cache.<kind>` or a PIXI_CACHE_*_DIR/RATTLER_CACHE_*_DIR env var) escapes to
+   the home filesystem. If not, it suggests symlinking ~/.cache/rattler onto
    /pkg/cmr (and flags any PIXI_CACHE_DIR/RATTLER_CACHE_DIR that would override
    the default cache location).
 5. `pixi config list --json` reports `detached-environments = true`
@@ -58,9 +60,18 @@ def run_command(cmd, capture_output=True):
 
 
 def resolve_path(path):
-    """Resolve a path using readlink -f to handle symlinks."""
-    resolved = run_command(f"readlink -f {path}")
-    return resolved if resolved else str(path)
+    """Resolve a path (following symlinks) without invoking a shell.
+
+    Uses os.path.realpath rather than shelling out to `readlink -f`, so paths
+    that originate from user-controlled sources (e.g. pixi's cache.root) cannot
+    inject shell commands.
+    """
+    if not path:
+        return str(path)
+    try:
+        return os.path.realpath(str(path))
+    except OSError:
+        return str(path)
 
 
 def is_within_weka(path):
@@ -79,6 +90,21 @@ def is_within_weka(path):
         return True
     
     return False
+
+
+def looks_like_pixi_cache_dir(path):
+    """Heuristically decide whether `path` is a dedicated pixi/rattler cache dir.
+
+    Used to gate the destructive `rm -rf` deletion hint: we only suggest wiping
+    the whole path when its final component is a recognizable cache directory
+    name (so we never propose `rm -rf $HOME` or `rm -rf /tmp`).
+    """
+    if not path:
+        return False
+    basename = os.path.basename(str(path).rstrip('/')).lower()
+    # The final path component must itself name a cache dir, so we never propose
+    # rm -rf on a broad root like $HOME (basename = username) or /tmp.
+    return any(token in basename for token in ('cache', 'rattler', 'pixi'))
 
 
 def parse_condarc_line(line):
@@ -232,8 +258,52 @@ def get_pixi_cache_dir():
     return None, None
 
 
+def find_misplaced_pixi_cache_overrides():
+    """Find per-kind pixi cache overrides that point outside /pkg/cmr or /mnt/weka.
+
+    Pixi lets individual cache kinds be redirected independently of the root,
+    both via config (``cache.conda-packages``, ``cache.repodata`` …) and via
+    per-kind env vars (``PIXI_CACHE_CONDA_PACKAGES_DIR`` etc.). These override
+    the root cache dir, so a good root does not guarantee everything lands on
+    the shared filesystem. Returns a list of (source, path) tuples for any
+    misplaced override, ignoring ones already within /pkg/cmr or /mnt/weka.
+    """
+    misplaced = []
+
+    # Config: any string path under the `cache` table other than `root`.
+    config, _ = load_pixi_config()
+    cache_cfg = config.get('cache') if isinstance(config, dict) else None
+    if isinstance(cache_cfg, dict):
+        for kind, value in cache_cfg.items():
+            if kind == 'root' or not isinstance(value, str):
+                continue
+            # Only treat absolute-ish paths as cache-dir overrides (some kinds,
+            # e.g. netfs-redirect, take non-path values).
+            if not (value.startswith('/') or value.startswith('~')):
+                continue
+            if not is_within_weka(os.path.expanduser(value)):
+                misplaced.append((f"config cache.{kind}", value))
+
+    # Env vars: PIXI_CACHE_*_DIR / RATTLER_CACHE_*_DIR beyond the root ones,
+    # which get_pixi_cache_dir()/the root check already handle.
+    root_vars = {'PIXI_CACHE_DIR', 'RATTLER_CACHE_DIR'}
+    for var_name, value in os.environ.items():
+        if var_name in root_vars or not value:
+            continue
+        if (var_name.startswith('PIXI_CACHE_') or var_name.startswith('RATTLER_CACHE_')) \
+                and var_name.endswith('_DIR'):
+            if not is_within_weka(os.path.expanduser(value)):
+                misplaced.append((f"${var_name}", value))
+
+    return misplaced
+
+
 def check_pixi_cache_dir():
     """Check that the effective pixi cache dir is within /pkg/cmr or /mnt/weka.
+
+    Also checks per-kind cache overrides (config and env vars), since a good
+    root cache dir does not stop pixi writing an individual cache kind onto the
+    home filesystem.
 
     Returns (ok, cache_dir, message). ``cache_dir`` is the effective path (or
     None if it could not be determined) so callers can suggest deleting it.
@@ -247,16 +317,25 @@ def check_pixi_cache_dir():
             "RATTLER_CACHE_DIR is set)"
         )
 
-    if is_within_weka(cache_dir):
-        return True, cache_dir, (
-            f"pixi cache dir is correctly within /pkg/cmr or /mnt/weka: "
-            f"{cache_dir} (via {source})"
+    if not is_within_weka(cache_dir):
+        resolved = resolve_path(cache_dir)
+        return False, cache_dir, (
+            f"pixi cache dir '{cache_dir}' (resolves to '{resolved}', via {source}) "
+            f"is not within /pkg/cmr or /mnt/weka"
         )
 
-    resolved = resolve_path(cache_dir)
-    return False, cache_dir, (
-        f"pixi cache dir '{cache_dir}' (resolves to '{resolved}', via {source}) "
-        f"is not within /pkg/cmr or /mnt/weka"
+    # Root is fine; make sure no per-kind override escapes to the home fs.
+    misplaced = find_misplaced_pixi_cache_overrides()
+    if misplaced:
+        detail = "; ".join(f"{src} -> {path}" for src, path in misplaced)
+        return False, cache_dir, (
+            f"pixi cache root is within /pkg/cmr or /mnt/weka ({cache_dir}), but "
+            f"per-kind cache override(s) point elsewhere: {detail}"
+        )
+
+    return True, cache_dir, (
+        f"pixi cache dir is correctly within /pkg/cmr or /mnt/weka: "
+        f"{cache_dir} (via {source})"
     )
 
 
@@ -395,8 +474,16 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
                 and resolve_path(pixi_cache_dir) != resolve_path(os.path.expanduser('~/.cache/rattler/cache')):
             # The misplaced cache is somewhere other than the default ~/.cache/rattler
             # that the rm above already removes; point it out so it can be reclaimed.
-            suggestions.append(f"   # Also delete the current misplaced cache dir to reclaim its space:")
-            suggestions.append(f"   rm -rf {shlex.quote(pixi_cache_dir)}")
+            if looks_like_pixi_cache_dir(pixi_cache_dir):
+                suggestions.append(f"   # Also delete the current misplaced cache dir to reclaim its space:")
+                suggestions.append(f"   rm -rf {shlex.quote(pixi_cache_dir)}")
+            else:
+                # The path does not clearly look like a dedicated cache dir (e.g.
+                # PIXI_CACHE_DIR=$HOME or /tmp). Suggesting `rm -rf` on it could
+                # wipe unrelated files, so ask the user to clean it up by hand.
+                suggestions.append(f"   # The current cache dir ({pixi_cache_dir}) does not look like a")
+                suggestions.append(f"   # dedicated cache dir, so inspect and remove its contents manually")
+                suggestions.append(f"   # rather than running rm -rf on the whole path.")
         step_num += 1
 
     if not pixi_detached_ok:

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -260,6 +260,43 @@ def get_pixi_cache_dir():
     return None, None
 
 
+def get_pixi_config_locations():
+    """Return the list of config files pixi is loading (from `pixi info --json`)."""
+    output = run_command('pixi info --json')
+    if not output:
+        return []
+    try:
+        info = json.loads(output)
+    except json.JSONDecodeError:
+        return []
+    locations = info.get('config_locations') if isinstance(info, dict) else None
+    return locations if isinstance(locations, list) else []
+
+
+def find_local_pixi_config():
+    """Return a project-local pixi config path if one is in effect, else None.
+
+    A config location is "local" (workspace-scoped, and higher priority than the
+    global config) when it is not under the user's global pixi config dirs. When
+    such a file is present, cache fixes must target it (`pixi config set --local`
+    / editing the file) because a `--global` change would be overridden by it.
+    """
+    home = os.path.expanduser('~')
+    global_roots = [
+        os.path.realpath(os.path.join(home, '.pixi')),
+        os.path.realpath(os.path.join(home, '.config', 'pixi')),
+    ]
+    pixi_home = os.environ.get('PIXI_HOME')
+    if pixi_home:
+        global_roots.append(os.path.realpath(pixi_home))
+
+    for loc in get_pixi_config_locations():
+        real = os.path.realpath(os.path.expanduser(str(loc)))
+        if not any(real.startswith(root) for root in global_roots):
+            return loc
+    return None
+
+
 def find_misplaced_pixi_cache_overrides():
     """Find per-kind pixi cache overrides that point outside /pkg/cmr or /mnt/weka.
 
@@ -465,6 +502,13 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
             None,
         )
         default_cache = resolve_path('~/.cache/rattler/cache')
+        # A workspace-local .pixi/config.toml overrides the global config and is
+        # already reflected by `pixi info`, so config-derived cache fixes must
+        # target that scope (a `--global` change would be overridden by it).
+        local_config = find_local_pixi_config()
+        config_scope = '--local' if local_config else '--global'
+        scope_note = (f" (in {local_config})" if local_config
+                      else "")
         # The root cache dir is "fine" only when we could determine it AND it is
         # within weka; in that case the check failed purely on a per-kind override
         # (handled below) so no root-level fix is needed. An unknown root
@@ -493,10 +537,10 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
             # cache.root config wins over the default location, so the symlink is
             # ignored; fix the config instead.
             suggestions.append(f"{step_num}. Point the pixi cache at /pkg/cmr. Your pixi `cache.root` config "
-                               f"sets it to {pixi_cache_dir}, which overrides the default location, so update it:")
+                               f"sets it to {pixi_cache_dir}, which overrides the default location, so update it{scope_note}:")
             suggestions.append(f"   mkdir -p {suggested_cache_dir}")
-            suggestions.append(f"   pixi config set --global cache.root {suggested_cache_dir}")
-            suggestions.append(f"   # (or unset it: pixi config unset --global cache.root)")
+            suggestions.append(f"   pixi config set {config_scope} cache.root {suggested_cache_dir}")
+            suggestions.append(f"   # (or unset it: pixi config unset {config_scope} cache.root)")
             if looks_like_pixi_cache_dir(pixi_cache_dir):
                 suggestions.append(f"   # Then delete the old cache dir to reclaim its space:")
                 suggestions.append(f"   rm -rf {shlex.quote(pixi_cache_dir)}")
@@ -529,8 +573,8 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
                 # src is like "config cache.<kind>"
                 key = src.split(' ', 1)[1] if ' ' in src else src
                 suggestions.append(f"{step_num}. The per-kind pixi cache config `{key}` = {path} points off /pkg/cmr "
-                                   f"and overrides the cache root, so update or unset it:")
-                suggestions.append(f"   pixi config unset --global {key}   # (or set it under /pkg/cmr)")
+                                   f"and overrides the cache root, so update or unset it{scope_note}:")
+                suggestions.append(f"   pixi config unset {config_scope} {key}   # (or set it under /pkg/cmr)")
             step_num += 1
 
     if not pixi_detached_ok:

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -316,6 +316,63 @@ def find_local_pixi_config():
     return None
 
 
+def _is_project_local_config(path):
+    """True if `path` looks like a project-local pixi config (not global/system)."""
+    real = os.path.realpath(os.path.expanduser(str(path)))
+    parent = os.path.basename(os.path.dirname(real))
+    name = os.path.basename(real)
+    return (name == 'config.toml' and parent == '.pixi') \
+        or name in ('pixi.toml', 'pyproject.toml')
+
+
+def _config_defines_cache_key(config_path, cache_key):
+    """Whether a pixi config file defines cache.<cache_key> (best-effort).
+
+    `cache_key` is like ``root`` or ``conda-packages``. Parses TOML if a parser
+    is available (tomllib on 3.11+, else tomli); on any failure returns None so
+    the caller can fall back to a conservative default.
+    """
+    try:
+        import tomllib as _toml
+    except ImportError:
+        try:
+            import tomli as _toml
+        except ImportError:
+            return None
+    try:
+        with open(os.path.expanduser(str(config_path)), 'rb') as f:
+            data = _toml.load(f)
+    except (OSError, ValueError):
+        return None
+    # In pixi.toml/pyproject.toml, config lives under the tool namespace; in a
+    # standalone config.toml it is at the top level. Check both.
+    for root in (data, data.get('tool', {}).get('pixi', {}) if isinstance(data, dict) else {}):
+        cache = root.get('cache') if isinstance(root, dict) else None
+        if isinstance(cache, dict) and cache_key in cache:
+            return True
+    return False
+
+
+def pixi_config_scope_for_cache_key(cache_key):
+    """Pick the (scope_flag, note) to fix a bad cache.<cache_key> config value.
+
+    Returns ('--local', ' (in <path>)') only when the key is actually defined in
+    a project-local config that is in effect; otherwise ('--global', ''). This
+    avoids suggesting `--local` for a value that really comes from the global
+    config (which `--local` would not change).
+    """
+    for loc in get_pixi_config_locations():
+        if not _is_project_local_config(loc):
+            continue
+        defines = _config_defines_cache_key(loc, cache_key)
+        # True -> the key really is set here. None -> could not parse; be
+        # conservative and still prefer --local, since a local config is the
+        # highest-priority scope pixi is loading and may well own the key.
+        if defines or defines is None:
+            return '--local', f" (in {loc})"
+    return '--global', ''
+
+
 def find_misplaced_pixi_cache_overrides():
     """Find per-kind pixi cache overrides that point outside /pkg/cmr or /mnt/weka.
 
@@ -521,13 +578,11 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
             None,
         )
         default_cache = resolve_path('~/.cache/rattler/cache')
-        # A workspace-local .pixi/config.toml overrides the global config and is
-        # already reflected by `pixi info`, so config-derived cache fixes must
-        # target that scope (a `--global` change would be overridden by it).
-        local_config = find_local_pixi_config()
-        config_scope = '--local' if local_config else '--global'
-        scope_note = (f" (in {local_config})" if local_config
-                      else "")
+        # The right pixi config scope for a config-derived fix depends on which
+        # config file actually defines the offending key: a project-local
+        # .pixi/config.toml overrides the global one, but a bad value may equally
+        # come from the global config even when a local config is present. Choose
+        # the scope per key (see pixi_config_scope_for_cache_key).
         # The root cache dir is "fine" only when we could determine it AND it is
         # within weka; in that case the check failed purely on a per-kind override
         # (handled below) so no root-level fix is needed. An unknown root
@@ -554,12 +609,13 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
             step_num += 1
         elif cache_from_config_root:
             # cache.root config wins over the default location, so the symlink is
-            # ignored; fix the config instead.
+            # ignored; fix the config instead, in whichever scope defines it.
+            root_scope, root_note = pixi_config_scope_for_cache_key('root')
             suggestions.append(f"{step_num}. Point the pixi cache at /pkg/cmr. Your pixi `cache.root` config "
-                               f"sets it to {pixi_cache_dir}, which overrides the default location, so update it{scope_note}:")
+                               f"sets it to {pixi_cache_dir}, which overrides the default location, so update it{root_note}:")
             suggestions.append(f"   mkdir -p {suggested_cache_dir}")
-            suggestions.append(f"   pixi config set {config_scope} cache.root {suggested_cache_dir}")
-            suggestions.append(f"   # (or unset it: pixi config unset {config_scope} cache.root)")
+            suggestions.append(f"   pixi config set {root_scope} cache.root {suggested_cache_dir}")
+            suggestions.append(f"   # (or unset it: pixi config unset {root_scope} cache.root)")
             if looks_like_pixi_cache_dir(pixi_cache_dir):
                 suggestions.append(f"   # Then delete the old cache dir to reclaim its space:")
                 suggestions.append(f"   rm -rf {shlex.quote(pixi_cache_dir)}")
@@ -591,9 +647,13 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
             else:
                 # src is like "config cache.<kind>"
                 key = src.split(' ', 1)[1] if ' ' in src else src
+                # `key` includes the `cache.` prefix; the cache table entry name
+                # is the part after it.
+                cache_kind = key.split('.', 1)[1] if '.' in key else key
+                kind_scope, kind_note = pixi_config_scope_for_cache_key(cache_kind)
                 suggestions.append(f"{step_num}. The per-kind pixi cache config `{key}` = {path} points off /pkg/cmr "
-                                   f"and overrides the cache root, so update or unset it{scope_note}:")
-                suggestions.append(f"   pixi config unset {config_scope} {key}   # (or set it under /pkg/cmr)")
+                                   f"and overrides the cache root, so update or unset it{kind_note}:")
+                suggestions.append(f"   pixi config unset {kind_scope} {key}   # (or set it under /pkg/cmr)")
             step_num += 1
 
     if not pixi_detached_ok:

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -395,14 +395,17 @@ def find_misplaced_pixi_cache_overrides():
     """
     misplaced = []
 
-    def _kind_env_vars(kind):
-        """Per-kind cache env var names for a `cache.<kind>` key.
+    def _kind_env_var(kind):
+        """The per-kind cache env var name for a `cache.<kind>` key.
 
         pixi maps e.g. cache.conda-packages -> PIXI_CACHE_CONDA_PACKAGES_DIR
-        (uppercase, '-' -> '_'); the RATTLER_ prefix is the equivalent alias.
+        (uppercase, '-' -> '_'). Only the PIXI_CACHE_<KIND>_DIR form is a
+        documented per-kind override; there is no RATTLER_ per-kind alias, so we
+        must not treat one as shadowing the config value (that would hide a real
+        misconfiguration).
         """
         token = kind.upper().replace('-', '_')
-        return (f"PIXI_CACHE_{token}_DIR", f"RATTLER_CACHE_{token}_DIR")
+        return f"PIXI_CACHE_{token}_DIR"
 
     # Config: any string path under the `cache` table other than `root`.
     config, _ = load_pixi_config()
@@ -419,7 +422,7 @@ def find_misplaced_pixi_cache_overrides():
             # (pixi resolution order: env var before [cache.<kind>]). If such an
             # env var is set, the config value is shadowed — skip it here and let
             # the env-var loop below judge the effective value.
-            if any(os.environ.get(v) for v in _kind_env_vars(kind)):
+            if os.environ.get(_kind_env_var(kind)):
                 continue
             if not is_within_weka(os.path.expanduser(value)):
                 misplaced.append((f"config cache.{kind}", value))

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -7,8 +7,11 @@ This script checks a user's ~/.condarc file to ensure:
 2. The first element of pkg_dirs is within /pkg/cmr or /mnt/weka
 3. ~/.conda is symlinked to /pkg/cmr/[username]/.conda or /mnt/weka/pkg/cmr/[username]/.conda
 
-If `--pixi` is supplied, it also checks:
-4. PIXI_CACHE_DIR or RATTLER_CACHE_DIR points within /pkg/cmr or /mnt/weka
+It also checks pixi:
+4. The effective pixi cache dir (from `pixi info --json`, which accounts for
+   PIXI_CACHE_DIR/RATTLER_CACHE_DIR and the `cache.root` config key) is within
+   /pkg/cmr or /mnt/weka. If not, it suggests a `pixi config set` update and how
+   to delete the current (misplaced) cache dir.
 5. `pixi config list --json` reports `detached-environments = true`
 
 It also checks:
@@ -199,20 +202,60 @@ def check_conda_symlink():
         return False, f"~/.conda symlinked to wrong location: {actual_target}"
 
 
-def check_pixi_cache_dir():
-    """Check that the active pixi cache env var points within /pkg/cmr or /mnt/weka."""
+def get_pixi_cache_dir():
+    """Determine the effective pixi cache directory.
+
+    Prefers `pixi info --json`, whose ``cache_dir`` is the value pixi actually
+    uses (it already accounts for both the PIXI_CACHE_DIR/RATTLER_CACHE_DIR env
+    vars and the ``cache.root`` config key). Falls back to reading those env
+    vars directly if pixi cannot be run.
+
+    Returns a (cache_dir, source) tuple; both are None if it cannot be
+    determined.
+    """
+    output = run_command('pixi info --json')
+    if output:
+        try:
+            info = json.loads(output)
+        except json.JSONDecodeError:
+            info = None
+        if isinstance(info, dict) and info.get('cache_dir'):
+            return info['cache_dir'], 'pixi info'
+
     for var_name in ('PIXI_CACHE_DIR', 'RATTLER_CACHE_DIR'):
         value = os.environ.get(var_name)
-        if not value:
-            continue
+        if value:
+            return value, var_name
 
-        if is_within_weka(value):
-            return True, f"{var_name} is correctly within /pkg/cmr or /mnt/weka: {value}"
+    return None, None
 
-        resolved = resolve_path(value)
-        return False, f"{var_name}='{value}' (resolves to '{resolved}') is not within /pkg/cmr or /mnt/weka"
 
-    return False, "Neither PIXI_CACHE_DIR nor RATTLER_CACHE_DIR is set"
+def check_pixi_cache_dir():
+    """Check that the effective pixi cache dir is within /pkg/cmr or /mnt/weka.
+
+    Returns (ok, cache_dir, message). ``cache_dir`` is the effective path (or
+    None if it could not be determined) so callers can suggest deleting it.
+    """
+    cache_dir, source = get_pixi_cache_dir()
+
+    if not cache_dir:
+        return False, None, (
+            "Could not determine the pixi cache dir "
+            "(pixi could not be run and neither PIXI_CACHE_DIR nor "
+            "RATTLER_CACHE_DIR is set)"
+        )
+
+    if is_within_weka(cache_dir):
+        return True, cache_dir, (
+            f"pixi cache dir is correctly within /pkg/cmr or /mnt/weka: "
+            f"{cache_dir} (via {source})"
+        )
+
+    resolved = resolve_path(cache_dir)
+    return False, cache_dir, (
+        f"pixi cache dir '{cache_dir}' (resolves to '{resolved}', via {source}) "
+        f"is not within /pkg/cmr or /mnt/weka"
+    )
 
 
 def load_pixi_config():
@@ -282,7 +325,7 @@ solver: libmamba
     return template
 
 
-def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_logs_ok, pixi_cache_ok, pixi_detached_ok, ps1_ok=True):
+def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_logs_ok, pixi_cache_ok, pixi_detached_ok, ps1_ok=True, pixi_cache_dir=None):
     """Generate suggestions for fixing conda and optional pixi configuration issues."""
     username = getpass.getuser()
     suggestions = []
@@ -328,9 +371,13 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
         step_num += 1
 
     if not pixi_cache_ok:
-        suggestions.append(f"{step_num}. Set PIXI_CACHE_DIR or RATTLER_CACHE_DIR to a path on /mnt/weka or /pkg/cmr by e.g. adding it to your ~/.bashrc (~/.bash_profile should also work):")
-        suggestions.append(f"   echo 'export PIXI_CACHE_DIR=/mnt/weka/pkg/cmr/{username}/pixi/cache' >> ~/.bashrc")
-        suggestions.append(f"   # Or set RATTLER_CACHE_DIR to a similar location")
+        suggested_cache_dir = f"/mnt/weka/pkg/cmr/{username}/pixi/cache"
+        suggestions.append(f"{step_num}. Point the pixi cache at /mnt/weka or /pkg/cmr via pixi config:")
+        suggestions.append(f"   pixi config set --global cache.root {suggested_cache_dir}")
+        suggestions.append(f"   # (equivalently, export PIXI_CACHE_DIR={suggested_cache_dir} from your ~/.bashrc)")
+        if pixi_cache_dir and not is_within_weka(pixi_cache_dir):
+            suggestions.append(f"   # Then delete the misplaced cache dir to reclaim its space:")
+            suggestions.append(f"   rm -rf {pixi_cache_dir}")
         step_num += 1
 
     if not pixi_detached_ok:
@@ -459,7 +506,7 @@ def main():
     # Check old qsub log folders
     qsub_logs_ok, qsub_logs_msg = check_old_qsub_logs()
 
-    pixi_cache_ok, pixi_cache_msg = check_pixi_cache_dir()
+    pixi_cache_ok, pixi_cache_dir, pixi_cache_msg = check_pixi_cache_dir()
     pixi_detached_ok, pixi_detached_msg = check_pixi_detached_environments()
 
     ps1_ok, ps1_msg = check_ps1()
@@ -531,6 +578,7 @@ def main():
             pixi_cache_ok,
             pixi_detached_ok,
             ps1_ok,
+            pixi_cache_dir,
         )
         if suggestions:
             print("")

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -64,14 +64,16 @@ def resolve_path(path):
 
     Uses os.path.realpath rather than shelling out to `readlink -f`, so paths
     that originate from user-controlled sources (e.g. pixi's cache.root) cannot
-    inject shell commands.
+    inject shell commands. Expands a leading ~ and $VARs first, matching what
+    the old shell-based `readlink -f ~/...` did (realpath alone leaves ~ literal).
     """
     if not path:
         return str(path)
+    expanded = os.path.expanduser(os.path.expandvars(str(path)))
     try:
-        return os.path.realpath(str(path))
+        return os.path.realpath(expanded)
     except OSError:
-        return str(path)
+        return expanded
 
 
 def is_within_weka(path):
@@ -453,37 +455,54 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
 
     if not pixi_cache_ok:
         suggested_cache_dir = f"/pkg/cmr/{username}/pixi/cache"
-        # pixi's default cache lives at ~/.cache/rattler; symlinking that dir onto
-        # /pkg/cmr keeps the cache off the home filesystem without any pixi config.
-        suggestions.append(f"{step_num}. Redirect the pixi/rattler cache onto /pkg/cmr by symlinking ~/.cache/rattler:")
-        suggestions.append(f"   mkdir -p {suggested_cache_dir}")
-        suggestions.append(f"   rm -rf ~/.cache/rattler")
-        suggestions.append(f"   ln -s {suggested_cache_dir} ~/.cache/rattler")
-        # The symlink only takes effect if pixi is using its default cache location.
-        # PIXI_CACHE_DIR / RATTLER_CACHE_DIR override it, so flag any that is set.
+        # pixi resolves the cache dir in order: PIXI_CACHE_DIR, RATTLER_CACHE_DIR,
+        # the `cache.root` config key, then the platform default (~/.cache/rattler).
+        # The right fix depends on which of these is placing the cache badly, since
+        # the earlier ones override a ~/.cache/rattler symlink.
         overriding_env = next(
             (v for v in ('PIXI_CACHE_DIR', 'RATTLER_CACHE_DIR')
              if os.environ.get(v) and not is_within_weka(os.environ[v])),
             None,
         )
+        default_cache = resolve_path('~/.cache/rattler/cache')
+        cache_from_config_root = (
+            not overriding_env
+            and pixi_cache_dir
+            and not is_within_weka(pixi_cache_dir)
+            and resolve_path(pixi_cache_dir) != default_cache
+        )
+
         if overriding_env:
-            suggestions.append(f"   # NOTE: ${overriding_env}={os.environ[overriding_env]} overrides the default "
-                               f"cache location, so the symlink above has no effect until you unset it "
-                               f"(e.g. remove the export from your ~/.bashrc).")
-        elif pixi_cache_dir and not is_within_weka(pixi_cache_dir) \
-                and resolve_path(pixi_cache_dir) != resolve_path(os.path.expanduser('~/.cache/rattler/cache')):
-            # The misplaced cache is somewhere other than the default ~/.cache/rattler
-            # that the rm above already removes; point it out so it can be reclaimed.
+            # A bad env var wins over both cache.root and the default location.
+            suggestions.append(f"{step_num}. Point the pixi cache at /pkg/cmr. "
+                               f"${overriding_env}={os.environ[overriding_env]} overrides pixi's cache "
+                               f"location, so update it (e.g. in your ~/.bashrc) rather than symlinking:")
+            suggestions.append(f"   export {overriding_env}={suggested_cache_dir}")
+            suggestions.append(f"   # (or unset {overriding_env} to fall back to cache.root / the default)")
+        elif cache_from_config_root:
+            # cache.root config wins over the default location, so the symlink is
+            # ignored; fix the config instead.
+            suggestions.append(f"{step_num}. Point the pixi cache at /pkg/cmr. Your pixi `cache.root` config "
+                               f"sets it to {pixi_cache_dir}, which overrides the default location, so update it:")
+            suggestions.append(f"   mkdir -p {suggested_cache_dir}")
+            suggestions.append(f"   pixi config set --global cache.root {suggested_cache_dir}")
+            suggestions.append(f"   # (or unset it: pixi config unset --global cache.root)")
             if looks_like_pixi_cache_dir(pixi_cache_dir):
-                suggestions.append(f"   # Also delete the current misplaced cache dir to reclaim its space:")
+                suggestions.append(f"   # Then delete the old cache dir to reclaim its space:")
                 suggestions.append(f"   rm -rf {shlex.quote(pixi_cache_dir)}")
             else:
                 # The path does not clearly look like a dedicated cache dir (e.g.
-                # PIXI_CACHE_DIR=$HOME or /tmp). Suggesting `rm -rf` on it could
-                # wipe unrelated files, so ask the user to clean it up by hand.
-                suggestions.append(f"   # The current cache dir ({pixi_cache_dir}) does not look like a")
-                suggestions.append(f"   # dedicated cache dir, so inspect and remove its contents manually")
-                suggestions.append(f"   # rather than running rm -rf on the whole path.")
+                # cache.root=$HOME). Wiping it could remove unrelated files, so
+                # ask the user to clean it up by hand rather than suggesting rm -rf.
+                suggestions.append(f"   # The old cache dir ({pixi_cache_dir}) does not look like a dedicated")
+                suggestions.append(f"   # cache dir, so inspect and remove its contents manually.")
+        else:
+            # The cache is at pixi's default ~/.cache/rattler location (just on the
+            # home fs); symlinking that dir onto /pkg/cmr fixes it with no config.
+            suggestions.append(f"{step_num}. Redirect the pixi/rattler cache onto /pkg/cmr by symlinking ~/.cache/rattler:")
+            suggestions.append(f"   mkdir -p {suggested_cache_dir}")
+            suggestions.append(f"   rm -rf ~/.cache/rattler")
+            suggestions.append(f"   ln -s {suggested_cache_dir} ~/.cache/rattler")
         step_num += 1
 
     if not pixi_detached_ok:

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -465,6 +465,11 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
             None,
         )
         default_cache = resolve_path('~/.cache/rattler/cache')
+        # The root cache dir is "fine" only when we could determine it AND it is
+        # within weka; in that case the check failed purely on a per-kind override
+        # (handled below) so no root-level fix is needed. An unknown root
+        # (pixi_cache_dir is None) still gets the default symlink guidance.
+        root_ok = bool(pixi_cache_dir) and is_within_weka(pixi_cache_dir)
         cache_from_config_root = (
             not overriding_env
             and pixi_cache_dir
@@ -472,13 +477,18 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
             and resolve_path(pixi_cache_dir) != default_cache
         )
 
-        if overriding_env:
+        if root_ok:
+            # The root is fine; the failure is purely per-kind overrides handled
+            # in the dedicated block below. Emit no root-level fix here.
+            pass
+        elif overriding_env:
             # A bad env var wins over both cache.root and the default location.
             suggestions.append(f"{step_num}. Point the pixi cache at /pkg/cmr. "
                                f"${overriding_env}={os.environ[overriding_env]} overrides pixi's cache "
                                f"location, so update it (e.g. in your ~/.bashrc) rather than symlinking:")
             suggestions.append(f"   export {overriding_env}={suggested_cache_dir}")
             suggestions.append(f"   # (or unset {overriding_env} to fall back to cache.root / the default)")
+            step_num += 1
         elif cache_from_config_root:
             # cache.root config wins over the default location, so the symlink is
             # ignored; fix the config instead.
@@ -496,6 +506,7 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
                 # ask the user to clean it up by hand rather than suggesting rm -rf.
                 suggestions.append(f"   # The old cache dir ({pixi_cache_dir}) does not look like a dedicated")
                 suggestions.append(f"   # cache dir, so inspect and remove its contents manually.")
+            step_num += 1
         else:
             # The cache is at pixi's default ~/.cache/rattler location (just on the
             # home fs); symlinking that dir onto /pkg/cmr fixes it with no config.
@@ -503,7 +514,24 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
             suggestions.append(f"   mkdir -p {suggested_cache_dir}")
             suggestions.append(f"   rm -rf ~/.cache/rattler")
             suggestions.append(f"   ln -s {suggested_cache_dir} ~/.cache/rattler")
-        step_num += 1
+            step_num += 1
+
+        # Per-kind cache overrides (config cache.<kind> / PIXI_CACHE_*_DIR) are
+        # applied before the root/default, so no root-level fix above can move
+        # them; each must be updated/unset on its own.
+        for src, path in find_misplaced_pixi_cache_overrides():
+            if src.startswith('$'):
+                var = src[1:]
+                suggestions.append(f"{step_num}. The per-kind cache override {src}={path} points off /pkg/cmr and "
+                                   f"overrides the cache root, so update or unset it (e.g. in your ~/.bashrc):")
+                suggestions.append(f"   unset {var}   # (or point it under /pkg/cmr)")
+            else:
+                # src is like "config cache.<kind>"
+                key = src.split(' ', 1)[1] if ' ' in src else src
+                suggestions.append(f"{step_num}. The per-kind pixi cache config `{key}` = {path} points off /pkg/cmr "
+                                   f"and overrides the cache root, so update or unset it:")
+                suggestions.append(f"   pixi config unset --global {key}   # (or set it under /pkg/cmr)")
+            step_num += 1
 
     if not pixi_detached_ok:
         suggestions.append(f"{step_num}. Enable detached pixi environments:")

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -10,8 +10,9 @@ This script checks a user's ~/.condarc file to ensure:
 It also checks pixi:
 4. The effective pixi cache dir (from `pixi info --json`, which accounts for
    PIXI_CACHE_DIR/RATTLER_CACHE_DIR and the `cache.root` config key) is within
-   /pkg/cmr or /mnt/weka. If not, it suggests a `pixi config set` update and how
-   to delete the current (misplaced) cache dir.
+   /pkg/cmr or /mnt/weka. If not, it suggests symlinking ~/.cache/rattler onto
+   /pkg/cmr (and flags any PIXI_CACHE_DIR/RATTLER_CACHE_DIR that would override
+   the default cache location).
 5. `pixi config list --json` reports `detached-environments = true`
 
 It also checks:
@@ -372,29 +373,29 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
         step_num += 1
 
     if not pixi_cache_ok:
-        suggested_cache_dir = f"/mnt/weka/pkg/cmr/{username}/pixi/cache"
-        # pixi resolves the cache root from PIXI_CACHE_DIR, then RATTLER_CACHE_DIR,
-        # before the cache.root config key. If a bad path comes from one of those
-        # env vars, setting cache.root will not change the effective cache, so
-        # tell the user to fix the overriding env var instead.
+        suggested_cache_dir = f"/pkg/cmr/{username}/pixi/cache"
+        # pixi's default cache lives at ~/.cache/rattler; symlinking that dir onto
+        # /pkg/cmr keeps the cache off the home filesystem without any pixi config.
+        suggestions.append(f"{step_num}. Redirect the pixi/rattler cache onto /pkg/cmr by symlinking ~/.cache/rattler:")
+        suggestions.append(f"   mkdir -p {suggested_cache_dir}")
+        suggestions.append(f"   rm -rf ~/.cache/rattler")
+        suggestions.append(f"   ln -s {suggested_cache_dir} ~/.cache/rattler")
+        # The symlink only takes effect if pixi is using its default cache location.
+        # PIXI_CACHE_DIR / RATTLER_CACHE_DIR override it, so flag any that is set.
         overriding_env = next(
             (v for v in ('PIXI_CACHE_DIR', 'RATTLER_CACHE_DIR')
              if os.environ.get(v) and not is_within_weka(os.environ[v])),
             None,
         )
         if overriding_env:
-            suggestions.append(f"{step_num}. Point the pixi cache at /mnt/weka or /pkg/cmr. "
-                               f"${overriding_env} currently overrides pixi's cache.root, so update it "
-                               f"(e.g. in your ~/.bashrc) rather than the config:")
-            suggestions.append(f"   export {overriding_env}={suggested_cache_dir}")
-            suggestions.append(f"   # (or unset {overriding_env} and set the config: "
-                               f"pixi config set --global cache.root {suggested_cache_dir})")
-        else:
-            suggestions.append(f"{step_num}. Point the pixi cache at /mnt/weka or /pkg/cmr via pixi config:")
-            suggestions.append(f"   pixi config set --global cache.root {suggested_cache_dir}")
-            suggestions.append(f"   # (equivalently, export PIXI_CACHE_DIR={suggested_cache_dir} from your ~/.bashrc)")
-        if pixi_cache_dir and not is_within_weka(pixi_cache_dir):
-            suggestions.append(f"   # Then delete the misplaced cache dir to reclaim its space:")
+            suggestions.append(f"   # NOTE: ${overriding_env}={os.environ[overriding_env]} overrides the default "
+                               f"cache location, so the symlink above has no effect until you unset it "
+                               f"(e.g. remove the export from your ~/.bashrc).")
+        elif pixi_cache_dir and not is_within_weka(pixi_cache_dir) \
+                and resolve_path(pixi_cache_dir) != resolve_path(os.path.expanduser('~/.cache/rattler/cache')):
+            # The misplaced cache is somewhere other than the default ~/.cache/rattler
+            # that the rm above already removes; point it out so it can be reclaimed.
+            suggestions.append(f"   # Also delete the current misplaced cache dir to reclaim its space:")
             suggestions.append(f"   rm -rf {shlex.quote(pixi_cache_dir)}")
         step_num += 1
 

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -427,14 +427,15 @@ def find_misplaced_pixi_cache_overrides():
             if not is_within_weka(os.path.expanduser(value)):
                 misplaced.append((f"config cache.{kind}", value))
 
-    # Env vars: PIXI_CACHE_*_DIR / RATTLER_CACHE_*_DIR beyond the root ones,
-    # which get_pixi_cache_dir()/the root check already handle.
-    root_vars = {'PIXI_CACHE_DIR', 'RATTLER_CACHE_DIR'}
+    # Per-kind cache env vars: only PIXI_CACHE_<KIND>_DIR is a documented per-kind
+    # override (there is no RATTLER_ per-kind alias; RATTLER_CACHE_DIR is only the
+    # root alias, handled by get_pixi_cache_dir()/the root check). Flagging a
+    # RATTLER_CACHE_<KIND>_DIR pixi would ignore is a false positive, so scan only
+    # PIXI_CACHE_*_DIR beyond the root var.
     for var_name, value in os.environ.items():
-        if var_name in root_vars or not value:
+        if var_name == 'PIXI_CACHE_DIR' or not value:
             continue
-        if (var_name.startswith('PIXI_CACHE_') or var_name.startswith('RATTLER_CACHE_')) \
-                and var_name.endswith('_DIR'):
+        if var_name.startswith('PIXI_CACHE_') and var_name.endswith('_DIR'):
             if not is_within_weka(os.path.expanduser(value)):
                 misplaced.append((f"${var_name}", value))
 

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -276,23 +276,42 @@ def get_pixi_config_locations():
 def find_local_pixi_config():
     """Return a project-local pixi config path if one is in effect, else None.
 
-    A config location is "local" (workspace-scoped, and higher priority than the
-    global config) when it is not under the user's global pixi config dirs. When
-    such a file is present, cache fixes must target it (`pixi config set --local`
-    / editing the file) because a `--global` change would be overridden by it.
+    Only a workspace/project config (``<project>/.pixi/config.toml``, or the
+    project manifest ``pixi.toml``/``pyproject.toml``) counts as "local": those
+    override the global config and require ``pixi config set --local``. System
+    and user locations reported by pixi (``/etc/pixi/config.toml``,
+    ``$XDG_CONFIG_HOME/pixi/config.toml``, ``~/.config/pixi``, ``~/.pixi``,
+    ``$PIXI_HOME``, ``$PIXI_CONFIG_FILE``) are matched positively and excluded,
+    so we never emit ``--local`` for a global/system config.
     """
-    home = os.path.expanduser('~')
-    global_roots = [
-        os.path.realpath(os.path.join(home, '.pixi')),
-        os.path.realpath(os.path.join(home, '.config', 'pixi')),
-    ]
+    # Known non-project (global/system/user) config locations to exclude.
+    excluded = set()
+
+    def _add(path):
+        if path:
+            excluded.add(os.path.realpath(os.path.expanduser(path)))
+
+    _add('/etc/pixi/config.toml')
+    _add(os.path.join('~', '.pixi', 'config.toml'))
+    _add(os.path.join('~', '.config', 'pixi', 'config.toml'))
+    xdg = os.environ.get('XDG_CONFIG_HOME')
+    if xdg:
+        _add(os.path.join(xdg, 'pixi', 'config.toml'))
     pixi_home = os.environ.get('PIXI_HOME')
     if pixi_home:
-        global_roots.append(os.path.realpath(pixi_home))
+        _add(os.path.join(pixi_home, 'config.toml'))
+    _add(os.environ.get('PIXI_CONFIG_FILE'))
 
     for loc in get_pixi_config_locations():
         real = os.path.realpath(os.path.expanduser(str(loc)))
-        if not any(real.startswith(root) for root in global_roots):
+        if real in excluded:
+            continue
+        # A project-local config is `<project>/.pixi/config.toml` or the project
+        # manifest itself (config can live in pixi.toml/pyproject.toml).
+        parent = os.path.basename(os.path.dirname(real))
+        name = os.path.basename(real)
+        if (name == 'config.toml' and parent == '.pixi') \
+                or name in ('pixi.toml', 'pyproject.toml'):
             return loc
     return None
 

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -31,6 +31,7 @@ import argparse
 import getpass
 import json
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -372,12 +373,29 @@ def generate_fix_suggestions(env_dirs_ok, pkg_dirs_ok, conda_symlink_ok, qsub_lo
 
     if not pixi_cache_ok:
         suggested_cache_dir = f"/mnt/weka/pkg/cmr/{username}/pixi/cache"
-        suggestions.append(f"{step_num}. Point the pixi cache at /mnt/weka or /pkg/cmr via pixi config:")
-        suggestions.append(f"   pixi config set --global cache.root {suggested_cache_dir}")
-        suggestions.append(f"   # (equivalently, export PIXI_CACHE_DIR={suggested_cache_dir} from your ~/.bashrc)")
+        # pixi resolves the cache root from PIXI_CACHE_DIR, then RATTLER_CACHE_DIR,
+        # before the cache.root config key. If a bad path comes from one of those
+        # env vars, setting cache.root will not change the effective cache, so
+        # tell the user to fix the overriding env var instead.
+        overriding_env = next(
+            (v for v in ('PIXI_CACHE_DIR', 'RATTLER_CACHE_DIR')
+             if os.environ.get(v) and not is_within_weka(os.environ[v])),
+            None,
+        )
+        if overriding_env:
+            suggestions.append(f"{step_num}. Point the pixi cache at /mnt/weka or /pkg/cmr. "
+                               f"${overriding_env} currently overrides pixi's cache.root, so update it "
+                               f"(e.g. in your ~/.bashrc) rather than the config:")
+            suggestions.append(f"   export {overriding_env}={suggested_cache_dir}")
+            suggestions.append(f"   # (or unset {overriding_env} and set the config: "
+                               f"pixi config set --global cache.root {suggested_cache_dir})")
+        else:
+            suggestions.append(f"{step_num}. Point the pixi cache at /mnt/weka or /pkg/cmr via pixi config:")
+            suggestions.append(f"   pixi config set --global cache.root {suggested_cache_dir}")
+            suggestions.append(f"   # (equivalently, export PIXI_CACHE_DIR={suggested_cache_dir} from your ~/.bashrc)")
         if pixi_cache_dir and not is_within_weka(pixi_cache_dir):
             suggestions.append(f"   # Then delete the misplaced cache dir to reclaim its space:")
-            suggestions.append(f"   rm -rf {pixi_cache_dir}")
+            suggestions.append(f"   rm -rf {shlex.quote(pixi_cache_dir)}")
         step_num += 1
 
     if not pixi_detached_ok:

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -366,20 +366,29 @@ def _config_defines_cache_key(config_path, cache_key):
 def pixi_config_scope_for_cache_key(cache_key):
     """Pick the (scope_flag, note) to fix a bad cache.<cache_key> config value.
 
-    Returns ('--local', ' (in <path>)') only when the key is actually defined in
-    a project-local config that is in effect; otherwise ('--global', ''). This
-    avoids suggesting `--local` for a value that really comes from the global
-    config (which `--local` would not change).
+    Returns ('--local', ' (in <path>)') only when we can CONFIRM the key is
+    defined in a project-local config in effect; otherwise ('--global', ...).
+
+    We only trust a confirmed local definition. If a local config exists but no
+    TOML parser is available to inspect it (`defines is None`), we do NOT assume
+    local ownership: guessing `--local` for a value that actually comes from the
+    global config would leave the global setting (and the failure) in place.
+    Instead we fall back to `--global` — which fixes the common case and works
+    outside a workspace — and, when a local config is present, name it so the
+    user can also check/override it there.
     """
+    unparsed_local = None
     for loc in get_pixi_config_locations():
         if not _is_project_local_config(loc):
             continue
         defines = _config_defines_cache_key(loc, cache_key)
-        # True -> the key really is set here. None -> could not parse; be
-        # conservative and still prefer --local, since a local config is the
-        # highest-priority scope pixi is loading and may well own the key.
-        if defines or defines is None:
+        if defines:
             return '--local', f" (in {loc})"
+        if defines is None and unparsed_local is None:
+            unparsed_local = loc
+    if unparsed_local is not None:
+        return '--global', (f" (globally; if it persists, also check/override "
+                            f"cache.{cache_key} in {unparsed_local})")
     return '--global', ''
 
 

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -283,18 +283,13 @@ def get_pixi_config_locations():
     return locations if isinstance(locations, list) else []
 
 
-def find_local_pixi_config():
-    """Return a project-local pixi config path if one is in effect, else None.
+def _excluded_pixi_config_paths():
+    """Realpaths of pixi's known global/system/user config locations.
 
-    Only a workspace/project config (``<project>/.pixi/config.toml``, or the
-    project manifest ``pixi.toml``/``pyproject.toml``) counts as "local": those
-    override the global config and require ``pixi config set --local``. System
-    and user locations reported by pixi (``/etc/pixi/config.toml``,
-    ``$XDG_CONFIG_HOME/pixi/config.toml``, ``~/.config/pixi``, ``~/.pixi``,
-    ``$PIXI_HOME``, ``$PIXI_CONFIG_FILE``) are matched positively and excluded,
-    so we never emit ``--local`` for a global/system config.
+    These are NEVER project-local: /etc/pixi/config.toml,
+    $XDG_CONFIG_HOME/pixi/config.toml, ~/.config/pixi, ~/.pixi, $PIXI_HOME, and
+    $PIXI_CONFIG_FILE (which pixi treats as the global config layer).
     """
-    # Known non-project (global/system/user) config locations to exclude.
     excluded = set()
 
     def _add(path):
@@ -311,28 +306,32 @@ def find_local_pixi_config():
     if pixi_home:
         _add(os.path.join(pixi_home, 'config.toml'))
     _add(os.environ.get('PIXI_CONFIG_FILE'))
-
-    for loc in get_pixi_config_locations():
-        real = os.path.realpath(os.path.expanduser(str(loc)))
-        if real in excluded:
-            continue
-        # A project-local config is `<project>/.pixi/config.toml` or the project
-        # manifest itself (config can live in pixi.toml/pyproject.toml).
-        parent = os.path.basename(os.path.dirname(real))
-        name = os.path.basename(real)
-        if (name == 'config.toml' and parent == '.pixi') \
-                or name in ('pixi.toml', 'pyproject.toml'):
-            return loc
-    return None
+    return excluded
 
 
 def _is_project_local_config(path):
-    """True if `path` looks like a project-local pixi config (not global/system)."""
+    """True if `path` is a project-local pixi config (not a global/system one).
+
+    A project-local config is ``<project>/.pixi/config.toml`` or the project
+    manifest (``pixi.toml``/``pyproject.toml``). Paths matching pixi's known
+    global/system/user locations are excluded even if their basename matches
+    (e.g. a $PIXI_CONFIG_FILE named pixi.toml is the global layer, not local).
+    """
     real = os.path.realpath(os.path.expanduser(str(path)))
+    if real in _excluded_pixi_config_paths():
+        return False
     parent = os.path.basename(os.path.dirname(real))
     name = os.path.basename(real)
     return (name == 'config.toml' and parent == '.pixi') \
         or name in ('pixi.toml', 'pyproject.toml')
+
+
+def find_local_pixi_config():
+    """Return a project-local pixi config path if one is in effect, else None."""
+    for loc in get_pixi_config_locations():
+        if _is_project_local_config(loc):
+            return loc
+    return None
 
 
 def _config_defines_cache_key(config_path, cache_key):

--- a/bin/mqlint
+++ b/bin/mqlint
@@ -385,6 +385,15 @@ def find_misplaced_pixi_cache_overrides():
     """
     misplaced = []
 
+    def _kind_env_vars(kind):
+        """Per-kind cache env var names for a `cache.<kind>` key.
+
+        pixi maps e.g. cache.conda-packages -> PIXI_CACHE_CONDA_PACKAGES_DIR
+        (uppercase, '-' -> '_'); the RATTLER_ prefix is the equivalent alias.
+        """
+        token = kind.upper().replace('-', '_')
+        return (f"PIXI_CACHE_{token}_DIR", f"RATTLER_CACHE_{token}_DIR")
+
     # Config: any string path under the `cache` table other than `root`.
     config, _ = load_pixi_config()
     cache_cfg = config.get('cache') if isinstance(config, dict) else None
@@ -395,6 +404,12 @@ def find_misplaced_pixi_cache_overrides():
             # Only treat absolute-ish paths as cache-dir overrides (some kinds,
             # e.g. netfs-redirect, take non-path values).
             if not (value.startswith('/') or value.startswith('~')):
+                continue
+            # A matching per-kind env var takes precedence over the config value
+            # (pixi resolution order: env var before [cache.<kind>]). If such an
+            # env var is set, the config value is shadowed — skip it here and let
+            # the env-var loop below judge the effective value.
+            if any(os.environ.get(v) for v in _kind_env_vars(kind)):
                 continue
             if not is_within_weka(os.path.expanduser(value)):
                 misplaced.append((f"config cache.{kind}", value))

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -360,6 +360,15 @@ class TestCmrLint(unittest.TestCase):
         self.assertIn(('config cache.conda-packages', '/home/testuser/cpkgs'), misplaced)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {'RATTLER_CACHE_CONDA_PACKAGES_DIR': '/home/testuser/cpkgs'}, clear=False)
+    def test_find_misplaced_pixi_cache_overrides_ignores_rattler_per_kind_env(self):
+        """A RATTLER_ per-kind env var is not a pixi override, so it isn't flagged."""
+        os.environ.pop('PIXI_CACHE_CONDA_PACKAGES_DIR', None)
+        with patch('cmr_lint.load_pixi_config', return_value=({}, None)):
+            misplaced = cmr_lint.find_misplaced_pixi_cache_overrides()
+        self.assertEqual(misplaced, [])
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_pixi_config_scope_for_cache_key(self):
         """Scope is --local only when the offending key is defined in a local config."""
         local = str(Path(self.test_dir) / '.pixi' / 'config.toml')

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -346,6 +346,21 @@ class TestCmrLint(unittest.TestCase):
         self.assertTrue(resolved.startswith('/'))
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    def test_resolve_path_expands_home(self):
+        """resolve_path expands a leading ~ (matching the old readlink -f ~/...)."""
+        resolved = cmr_lint.resolve_path('~/some/dir')
+        self.assertTrue(resolved.startswith(os.path.expanduser('~')))
+        self.assertNotIn('~', resolved)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    def test_is_within_weka_home_relative_symlink(self):
+        """A ~-relative path whose expansion is under /pkg/cmr counts as within weka."""
+        # Simulate ~ expanding to a /pkg/cmr home so no real symlink is needed.
+        with patch('cmr_lint.os.path.expanduser',
+                   side_effect=lambda p: p.replace('~', '/pkg/cmr/testuser', 1)):
+            self.assertTrue(cmr_lint.is_within_weka('~/conda/envs'))
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_get_pixi_cache_dir_prefers_pixi_info(self):
         """get_pixi_cache_dir uses the cache_dir reported by `pixi info --json`."""
         with patch('cmr_lint.run_command',
@@ -367,7 +382,24 @@ class TestCmrLint(unittest.TestCase):
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {}, clear=False)
     def test_generate_fix_suggestions_pixi_cache_symlink(self):
-        """A misplaced cache dir yields a ~/.cache/rattler symlink suggestion."""
+        """Cache at the default ~/.cache/rattler location yields a symlink suggestion."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        default_cache = os.path.expanduser('~/.cache/rattler/cache')
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'):
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir=default_cache)
+        text = '\n'.join(suggestions)
+        self.assertIn('ln -s /pkg/cmr/testuser/pixi/cache ~/.cache/rattler', text)
+        self.assertIn('rm -rf ~/.cache/rattler', text)
+        # The default location is fixed by the symlink; no cache.root change needed.
+        self.assertNotIn('cache.root', text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
+    def test_generate_fix_suggestions_pixi_cache_config_root(self):
+        """A bad cache.root (not the default location) yields a cache.root fix, not a symlink."""
         os.environ.pop('PIXI_CACHE_DIR', None)
         os.environ.pop('RATTLER_CACHE_DIR', None)
         with patch('cmr_lint.getpass.getuser', return_value='testuser'):
@@ -375,25 +407,27 @@ class TestCmrLint(unittest.TestCase):
                 True, True, True, True, False, True,
                 pixi_cache_dir='/tmp/pixi-cache')
         text = '\n'.join(suggestions)
-        self.assertIn('ln -s /pkg/cmr/testuser/pixi/cache ~/.cache/rattler', text)
-        self.assertIn('rm -rf ~/.cache/rattler', text)
-        # The misplaced dir is not the default cache, so it is also flagged for removal.
+        # cache.root overrides the default location, so the symlink would be ignored.
+        self.assertIn('pixi config set --global cache.root /pkg/cmr/testuser/pixi/cache', text)
+        self.assertNotIn('ln -s', text)
+        # The old cache dir looks like a cache, so its removal is offered.
         self.assertIn('rm -rf /tmp/pixi-cache', text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {'PIXI_CACHE_DIR': '/tmp/pixi-cache'}, clear=False)
     def test_generate_fix_suggestions_pixi_cache_env_override(self):
-        """A bad env var overrides the default cache, so the symlink alone won't help."""
+        """A bad env var overrides cache.root and the default, so fix the env var."""
         os.environ.pop('RATTLER_CACHE_DIR', None)
         with patch('cmr_lint.getpass.getuser', return_value='testuser'):
             suggestions = cmr_lint.generate_fix_suggestions(
                 True, True, True, True, False, True,
                 pixi_cache_dir='/tmp/pixi-cache')
         text = '\n'.join(suggestions)
-        # The symlink is still suggested, but the overriding env var must be flagged.
-        self.assertIn('ln -s /pkg/cmr/testuser/pixi/cache ~/.cache/rattler', text)
+        # The env var wins over both cache.root and the default; point at it.
         self.assertIn('PIXI_CACHE_DIR', text)
-        self.assertIn('overrides the default', text)
+        self.assertIn('overrides', text)
+        self.assertIn('export PIXI_CACHE_DIR=/pkg/cmr/testuser/pixi/cache', text)
+        self.assertNotIn('ln -s', text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {}, clear=False)

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -392,6 +392,14 @@ class TestCmrLint(unittest.TestCase):
             self.assertEqual(cmr_lint.pixi_config_scope_for_cache_key('root'),
                              ('--global', ''))
 
+        # Local config present but unparseable (no TOML parser): must NOT assume
+        # local ownership -> fall back to --global but name the local file.
+        with patch('cmr_lint.get_pixi_config_locations', return_value=[local]), \
+                patch('cmr_lint._config_defines_cache_key', return_value=None):
+            scope, note = cmr_lint.pixi_config_scope_for_cache_key('conda-packages')
+            self.assertEqual(scope, '--global')
+            self.assertIn(local, note)
+
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_resolve_path_does_not_invoke_shell(self):
         """resolve_path must not shell out (guards against command injection)."""

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -458,6 +458,21 @@ class TestCmrLint(unittest.TestCase):
             self.assertIsNone(cmr_lint.find_local_pixi_config())
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {'PIXI_CONFIG_FILE': '/custom/pixi.toml'}, clear=False)
+    def test_is_project_local_config_excludes_global_locations(self):
+        """The scope picker's classifier also excludes global/system locations."""
+        # PIXI_CONFIG_FILE is pixi's global layer even when named pixi.toml.
+        self.assertFalse(cmr_lint._is_project_local_config('/custom/pixi.toml'))
+        self.assertFalse(cmr_lint._is_project_local_config('/etc/pixi/config.toml'))
+        # A genuine project-local config is still local.
+        self.assertTrue(cmr_lint._is_project_local_config('/proj/.pixi/config.toml'))
+        # ...and via the scope picker, a PIXI_CONFIG_FILE-defined key is --global.
+        with patch('cmr_lint.get_pixi_config_locations',
+                   return_value=['/custom/pixi.toml']):
+            scope, _ = cmr_lint.pixi_config_scope_for_cache_key('root')
+            self.assertEqual(scope, '--global')
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_get_pixi_cache_dir_prefers_pixi_info(self):
         """get_pixi_cache_dir uses the cache_dir reported by `pixi info --json`."""
         with patch('cmr_lint.run_command',

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -63,7 +63,6 @@ class TestCmrLint(unittest.TestCase):
         self.assertIn('Check conda configuration', result.stdout)
         self.assertIn('--verbose', result.stdout)
         self.assertIn('--condarc', result.stdout)
-        self.assertIn('--pixi', result.stdout)
     
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_is_within_weka_direct_path(self):
@@ -277,21 +276,55 @@ class TestCmrLint(unittest.TestCase):
         self.assertIn('detached pixi environments', suggestion_text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
-    @patch.dict(os.environ, {'PIXI_CACHE_DIR': '/mnt/weka/pkg/cmr/testuser/pixi/cache'}, clear=False)
-    def test_check_pixi_cache_dir_valid(self):
+    @patch('cmr_lint.get_pixi_cache_dir',
+           return_value=('/mnt/weka/pkg/cmr/testuser/pixi/cache', 'pixi info'))
+    def test_check_pixi_cache_dir_valid(self, _mock_get):
         """Test pixi cache directory validation for a valid cache path."""
-        is_ok, message = cmr_lint.check_pixi_cache_dir()
+        is_ok, cache_dir, message = cmr_lint.check_pixi_cache_dir()
         self.assertTrue(is_ok)
-        self.assertIn('PIXI_CACHE_DIR', message)
+        self.assertEqual(cache_dir, '/mnt/weka/pkg/cmr/testuser/pixi/cache')
+        self.assertIn('/pkg/cmr or /mnt/weka', message)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
-    @patch.dict(os.environ, {'PIXI_CACHE_DIR': '/tmp/pixi-cache'}, clear=False)
+    @patch('cmr_lint.get_pixi_cache_dir',
+           return_value=('/tmp/pixi-cache', 'PIXI_CACHE_DIR'))
     @patch('cmr_lint.resolve_path', return_value='/tmp/pixi-cache')
-    def test_check_pixi_cache_dir_invalid(self, _mock_resolve):
+    def test_check_pixi_cache_dir_invalid(self, _mock_resolve, _mock_get):
         """Test pixi cache directory validation for an invalid cache path."""
-        is_ok, message = cmr_lint.check_pixi_cache_dir()
+        is_ok, cache_dir, message = cmr_lint.check_pixi_cache_dir()
         self.assertFalse(is_ok)
+        self.assertEqual(cache_dir, '/tmp/pixi-cache')
         self.assertIn('not within /pkg/cmr or /mnt/weka', message)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    def test_get_pixi_cache_dir_prefers_pixi_info(self):
+        """get_pixi_cache_dir uses the cache_dir reported by `pixi info --json`."""
+        with patch('cmr_lint.run_command',
+                   return_value='{"cache_dir": "/mnt/weka/pkg/cmr/testuser/pixi/cache"}'):
+            cache_dir, source = cmr_lint.get_pixi_cache_dir()
+        self.assertEqual(cache_dir, '/mnt/weka/pkg/cmr/testuser/pixi/cache')
+        self.assertEqual(source, 'pixi info')
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {'PIXI_CACHE_DIR': '/mnt/weka/pkg/cmr/testuser/pixi/cache'}, clear=False)
+    def test_get_pixi_cache_dir_falls_back_to_env(self):
+        """get_pixi_cache_dir falls back to env vars when pixi can't be run."""
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        with patch('cmr_lint.run_command', return_value=None):
+            cache_dir, source = cmr_lint.get_pixi_cache_dir()
+        self.assertEqual(cache_dir, '/mnt/weka/pkg/cmr/testuser/pixi/cache')
+        self.assertEqual(source, 'PIXI_CACHE_DIR')
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    def test_generate_fix_suggestions_pixi_cache_deletion(self):
+        """A misplaced cache dir yields a cache.root config fix and a deletion hint."""
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'):
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir='/tmp/pixi-cache')
+        text = '\n'.join(suggestions)
+        self.assertIn('pixi config set --global cache.root', text)
+        self.assertIn('rm -rf /tmp/pixi-cache', text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch('cmr_lint.subprocess.run')
@@ -343,7 +376,7 @@ class TestCmrLint(unittest.TestCase):
                 env={**os.environ, 'PYTHONPATH': str(Path(__file__).parent.parent / 'bin')}
             )
             
-            self.assertIn('conda configuration', result.stdout.lower())
+            self.assertIn('configuration', result.stdout.lower())
             
         finally:
             os.unlink(condarc_path)
@@ -356,12 +389,14 @@ class TestCmrLint(unittest.TestCase):
     @patch('cmr_lint.check_pkg_dirs')
     @patch('cmr_lint.check_env_dirs')
     def test_main_function_success(self, mock_env_dirs, mock_pkg_dirs, mock_symlink, mock_qsub_logs, mock_pixi_cache, mock_pixi_detached):
-        """Test main function when conda checks pass without pixi enabled."""
+        """Test main function when all checks (including pixi) pass."""
         mock_env_dirs.return_value = (True, "Environment directories OK")
-        mock_pkg_dirs.return_value = (True, "Package directories OK") 
+        mock_pkg_dirs.return_value = (True, "Package directories OK")
         mock_symlink.return_value = (True, "Symlink OK")
         mock_qsub_logs.return_value = (True, "No old qsub log folders found")
-        
+        mock_pixi_cache.return_value = (True, "/mnt/weka/pkg/cmr/testuser/pixi/cache", "pixi cache OK")
+        mock_pixi_detached.return_value = (True, "pixi config has detached-environments = true")
+
         # Create a valid config file
         with tempfile.NamedTemporaryFile(mode='w', suffix='.condarc', delete=False) as f:
             config = {
@@ -370,44 +405,11 @@ class TestCmrLint(unittest.TestCase):
             }
             write_condarc_format(config, f)
             condarc_path = f.name
-        
+
         try:
-            # Test that main exits with 0 when all checks pass
+            # Test that main exits with 0 when all checks pass. pixi checks are
+            # always run.
             with patch('sys.argv', ['cmr_lint.py', '--condarc', condarc_path]):
-                with self.assertRaises(SystemExit) as cm:
-                    cmr_lint.main()
-                self.assertEqual(cm.exception.code, 0)
-                mock_pixi_cache.assert_not_called()
-                mock_pixi_detached.assert_not_called()
-        finally:
-            os.unlink(condarc_path)
-
-    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
-    @patch('cmr_lint.check_pixi_detached_environments')
-    @patch('cmr_lint.check_pixi_cache_dir')
-    @patch('cmr_lint.check_old_qsub_logs')
-    @patch('cmr_lint.check_conda_symlink')
-    @patch('cmr_lint.check_pkg_dirs')
-    @patch('cmr_lint.check_env_dirs')
-    def test_main_function_success_with_pixi(self, mock_env_dirs, mock_pkg_dirs, mock_symlink, mock_qsub_logs, mock_pixi_cache, mock_pixi_detached):
-        """Test main function when pixi checks are explicitly enabled."""
-        mock_env_dirs.return_value = (True, "Environment directories OK")
-        mock_pkg_dirs.return_value = (True, "Package directories OK")
-        mock_symlink.return_value = (True, "Symlink OK")
-        mock_qsub_logs.return_value = (True, "No old qsub log folders found")
-        mock_pixi_cache.return_value = (True, "PIXI_CACHE_DIR is correctly within /pkg/cmr or /mnt/weka")
-        mock_pixi_detached.return_value = (True, "pixi config has detached-environments = true")
-
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.condarc', delete=False) as f:
-            config = {
-                'envs_dirs': ['/pkg/cmr/testuser/conda/envs'],
-                'pkgs_dirs': ['/pkg/cmr/testuser/conda/pkgs']
-            }
-            write_condarc_format(config, f)
-            condarc_path = f.name
-
-        try:
-            with patch('sys.argv', ['cmr_lint.py', '--pixi', '--condarc', condarc_path]):
                 with self.assertRaises(SystemExit) as cm:
                     cmr_lint.main()
                 self.assertEqual(cm.exception.code, 0)

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -375,6 +375,23 @@ class TestCmrLint(unittest.TestCase):
                    return_value=[os.path.join(home, '.pixi', 'config.toml'),
                                  '/proj/.pixi/config.toml']):
             self.assertEqual(cmr_lint.find_local_pixi_config(), '/proj/.pixi/config.toml')
+        # System/user locations must NOT be classified as local (comment #296).
+        with patch('cmr_lint.get_pixi_config_locations',
+                   return_value=['/etc/pixi/config.toml',
+                                 os.path.join(home, '.config', 'pixi', 'config.toml')]):
+            self.assertIsNone(cmr_lint.find_local_pixi_config())
+        # A project manifest carrying config counts as local.
+        with patch('cmr_lint.get_pixi_config_locations',
+                   return_value=['/proj/pixi.toml']):
+            self.assertEqual(cmr_lint.find_local_pixi_config(), '/proj/pixi.toml')
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {'PIXI_CONFIG_FILE': '/custom/pixi.toml'}, clear=False)
+    def test_find_local_pixi_config_excludes_pixi_config_file_env(self):
+        """A PIXI_CONFIG_FILE user location is not treated as project-local."""
+        with patch('cmr_lint.get_pixi_config_locations',
+                   return_value=['/custom/pixi.toml']):
+            self.assertIsNone(cmr_lint.find_local_pixi_config())
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_get_pixi_cache_dir_prefers_pixi_info(self):

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -337,6 +337,30 @@ class TestCmrLint(unittest.TestCase):
         self.assertEqual(misplaced, [('config cache.conda-packages', '/home/testuser/cpkgs')])
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    def test_pixi_config_scope_for_cache_key(self):
+        """Scope is --local only when the offending key is defined in a local config."""
+        local = str(Path(self.test_dir) / '.pixi' / 'config.toml')
+        os.makedirs(os.path.dirname(local), exist_ok=True)
+        with open(local, 'w') as f:
+            f.write('[cache]\nconda-packages = "/home/u/cpkgs"\n')
+
+        with patch('cmr_lint.get_pixi_config_locations', return_value=[local]):
+            # Key IS defined locally -> --local, naming the file.
+            scope, note = cmr_lint.pixi_config_scope_for_cache_key('conda-packages')
+            self.assertEqual(scope, '--local')
+            self.assertIn(local, note)
+            # A different key not defined locally -> --global (comes from global).
+            scope, note = cmr_lint.pixi_config_scope_for_cache_key('root')
+            self.assertEqual(scope, '--global')
+            self.assertEqual(note, '')
+
+        # No local config at all -> always --global.
+        with patch('cmr_lint.get_pixi_config_locations',
+                   return_value=['/etc/pixi/config.toml']):
+            self.assertEqual(cmr_lint.pixi_config_scope_for_cache_key('root'),
+                             ('--global', ''))
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_resolve_path_does_not_invoke_shell(self):
         """resolve_path must not shell out (guards against command injection)."""
         with patch('cmr_lint.run_command') as mock_run:
@@ -437,7 +461,7 @@ class TestCmrLint(unittest.TestCase):
         os.environ.pop('RATTLER_CACHE_DIR', None)
         overrides = [('config cache.conda-packages', '/home/testuser/cpkgs')]
         with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
-                patch('cmr_lint.find_local_pixi_config', return_value=None), \
+                patch('cmr_lint.pixi_config_scope_for_cache_key', return_value=('--global', '')), \
                 patch('cmr_lint.find_misplaced_pixi_cache_overrides', return_value=overrides):
             suggestions = cmr_lint.generate_fix_suggestions(
                 True, True, True, True, False, True,
@@ -451,16 +475,17 @@ class TestCmrLint(unittest.TestCase):
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {}, clear=False)
     def test_generate_fix_suggestions_pixi_cache_local_config_scope(self):
-        """A workspace-local pixi config makes cache fixes target --local, not --global."""
+        """When the offending key is defined locally, fixes target --local, naming the file."""
         os.environ.pop('PIXI_CACHE_DIR', None)
         os.environ.pop('RATTLER_CACHE_DIR', None)
         local = '/proj/.pixi/config.toml'
         overrides = [('config cache.conda-packages', '/home/testuser/cpkgs')]
         with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
-                patch('cmr_lint.find_local_pixi_config', return_value=local), \
+                patch('cmr_lint.pixi_config_scope_for_cache_key',
+                      return_value=('--local', f' (in {local})')), \
                 patch('cmr_lint.find_misplaced_pixi_cache_overrides', return_value=overrides):
             # Bad cache.root (config-derived) plus a per-kind override; both should
-            # use --local because the effective config is workspace-local.
+            # use --local because the offending key is defined in the local config.
             suggestions = cmr_lint.generate_fix_suggestions(
                 True, True, True, True, False, True,
                 pixi_cache_dir='/tmp/localbad')
@@ -493,7 +518,7 @@ class TestCmrLint(unittest.TestCase):
         os.environ.pop('PIXI_CACHE_DIR', None)
         os.environ.pop('RATTLER_CACHE_DIR', None)
         with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
-                patch('cmr_lint.find_local_pixi_config', return_value=None):
+                patch('cmr_lint.pixi_config_scope_for_cache_key', return_value=('--global', '')):
             suggestions = cmr_lint.generate_fix_suggestions(
                 True, True, True, True, False, True,
                 pixi_cache_dir='/tmp/pixi-cache')

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -279,9 +279,10 @@ class TestCmrLint(unittest.TestCase):
         self.assertIn('detached pixi environments', suggestion_text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch('cmr_lint.find_misplaced_pixi_cache_overrides', return_value=[])
     @patch('cmr_lint.get_pixi_cache_dir',
            return_value=('/mnt/weka/pkg/cmr/testuser/pixi/cache', 'pixi info'))
-    def test_check_pixi_cache_dir_valid(self, _mock_get):
+    def test_check_pixi_cache_dir_valid(self, _mock_get, _mock_overrides):
         """Test pixi cache directory validation for a valid cache path."""
         is_ok, cache_dir, message = cmr_lint.check_pixi_cache_dir()
         self.assertTrue(is_ok)
@@ -298,6 +299,51 @@ class TestCmrLint(unittest.TestCase):
         self.assertFalse(is_ok)
         self.assertEqual(cache_dir, '/tmp/pixi-cache')
         self.assertIn('not within /pkg/cmr or /mnt/weka', message)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch('cmr_lint.find_misplaced_pixi_cache_overrides',
+           return_value=[('config cache.conda-packages', '/home/testuser/cpkgs')])
+    @patch('cmr_lint.get_pixi_cache_dir',
+           return_value=('/mnt/weka/pkg/cmr/testuser/pixi/cache', 'pixi info'))
+    def test_check_pixi_cache_dir_good_root_bad_per_kind(self, _mock_get, _mock_overrides):
+        """A good root but a misplaced per-kind override should fail."""
+        is_ok, cache_dir, message = cmr_lint.check_pixi_cache_dir()
+        self.assertFalse(is_ok)
+        self.assertIn('per-kind cache override', message)
+        self.assertIn('cache.conda-packages', message)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {'PIXI_CACHE_CONDA_PACKAGES_DIR': '/home/testuser/cpkgs'}, clear=False)
+    def test_find_misplaced_pixi_cache_overrides_env(self):
+        """A per-kind cache env var pointing off /pkg/cmr is reported."""
+        with patch('cmr_lint.load_pixi_config', return_value=({}, None)):
+            misplaced = cmr_lint.find_misplaced_pixi_cache_overrides()
+        self.assertIn(('$PIXI_CACHE_CONDA_PACKAGES_DIR', '/home/testuser/cpkgs'), misplaced)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
+    def test_find_misplaced_pixi_cache_overrides_config(self):
+        """A per-kind cache config key pointing off /pkg/cmr is reported; root is ignored."""
+        for var in list(os.environ):
+            if var.startswith(('PIXI_CACHE_', 'RATTLER_CACHE_')):
+                os.environ.pop(var, None)
+        config = {'cache': {
+            'root': '/mnt/weka/pkg/cmr/testuser/pixi/cache',
+            'conda-packages': '/home/testuser/cpkgs',
+            'repodata': '/pkg/cmr/testuser/repodata',
+        }}
+        with patch('cmr_lint.load_pixi_config', return_value=(config, None)):
+            misplaced = cmr_lint.find_misplaced_pixi_cache_overrides()
+        self.assertEqual(misplaced, [('config cache.conda-packages', '/home/testuser/cpkgs')])
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    def test_resolve_path_does_not_invoke_shell(self):
+        """resolve_path must not shell out (guards against command injection)."""
+        with patch('cmr_lint.run_command') as mock_run:
+            resolved = cmr_lint.resolve_path('/tmp/x; touch /tmp/pwned')
+        mock_run.assert_not_called()
+        # os.path.realpath treats the whole string as a path, never executing it.
+        self.assertTrue(resolved.startswith('/'))
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_get_pixi_cache_dir_prefers_pixi_info(self):
@@ -361,6 +407,31 @@ class TestCmrLint(unittest.TestCase):
                 pixi_cache_dir='/tmp/pixi cache')
         text = '\n'.join(suggestions)
         self.assertIn("rm -rf '/tmp/pixi cache'", text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
+    def test_generate_fix_suggestions_pixi_cache_unsafe_path_no_rm(self):
+        """A cache dir that isn't clearly a cache (e.g. $HOME) is not rm -rf'd."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'):
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir='/home/testuser')
+        text = '\n'.join(suggestions)
+        self.assertNotIn('rm -rf /home/testuser', text)
+        self.assertNotIn("rm -rf '/home/testuser'", text)
+        self.assertIn('manually', text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    def test_looks_like_pixi_cache_dir(self):
+        """The rm-guard recognizes cache dirs but not broad roots."""
+        self.assertTrue(cmr_lint.looks_like_pixi_cache_dir('/tmp/pixi-cache'))
+        self.assertTrue(cmr_lint.looks_like_pixi_cache_dir('/home/u/.cache/rattler'))
+        self.assertTrue(cmr_lint.looks_like_pixi_cache_dir('/some/where/pixi'))
+        self.assertFalse(cmr_lint.looks_like_pixi_cache_dir('/home/testuser'))
+        self.assertFalse(cmr_lint.looks_like_pixi_cache_dir('/tmp'))
+        self.assertFalse(cmr_lint.looks_like_pixi_cache_dir(''))
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch('cmr_lint.subprocess.run')

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -348,6 +348,18 @@ class TestCmrLint(unittest.TestCase):
         self.assertEqual(misplaced, [])
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {'RATTLER_CACHE_CONDA_PACKAGES_DIR': '/pkg/cmr/testuser/cpkgs'}, clear=False)
+    def test_find_misplaced_pixi_cache_overrides_rattler_per_kind_not_shadowing(self):
+        """A RATTLER_ per-kind var does NOT shadow config (pixi honors PIXI_ only)."""
+        os.environ.pop('PIXI_CACHE_CONDA_PACKAGES_DIR', None)
+        # Bad config value must STILL be reported: pixi has no RATTLER_ per-kind
+        # override, so the config path is what pixi actually uses.
+        config = {'cache': {'conda-packages': '/home/testuser/cpkgs'}}
+        with patch('cmr_lint.load_pixi_config', return_value=(config, None)):
+            misplaced = cmr_lint.find_misplaced_pixi_cache_overrides()
+        self.assertIn(('config cache.conda-packages', '/home/testuser/cpkgs'), misplaced)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_pixi_config_scope_for_cache_key(self):
         """Scope is --local only when the offending key is defined in a local config."""
         local = str(Path(self.test_dir) / '.pixi' / 'config.toml')

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -398,6 +398,40 @@ class TestCmrLint(unittest.TestCase):
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {}, clear=False)
+    def test_generate_fix_suggestions_pixi_cache_per_kind_config(self):
+        """Good root but a bad per-kind config override => targeted unset, no symlink."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        overrides = [('config cache.conda-packages', '/home/testuser/cpkgs')]
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
+                patch('cmr_lint.find_misplaced_pixi_cache_overrides', return_value=overrides):
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir='/pkg/cmr/testuser/pixi/cache')
+        text = '\n'.join(suggestions)
+        # Root is fine, so no symlink/config.root fix, just the per-kind unset.
+        self.assertNotIn('ln -s', text)
+        self.assertNotIn('cache.root', text)
+        self.assertIn('pixi config unset --global cache.conda-packages', text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
+    def test_generate_fix_suggestions_pixi_cache_per_kind_env(self):
+        """Good root but a bad per-kind env override => suggest unsetting that var."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        overrides = [('$PIXI_CACHE_CONDA_PACKAGES_DIR', '/home/testuser/cpkgs')]
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
+                patch('cmr_lint.find_misplaced_pixi_cache_overrides', return_value=overrides):
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir='/pkg/cmr/testuser/pixi/cache')
+        text = '\n'.join(suggestions)
+        self.assertNotIn('ln -s', text)
+        self.assertIn('unset PIXI_CACHE_CONDA_PACKAGES_DIR', text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
     def test_generate_fix_suggestions_pixi_cache_config_root(self):
         """A bad cache.root (not the default location) yields a cache.root fix, not a symlink."""
         os.environ.pop('PIXI_CACHE_DIR', None)

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -262,17 +262,20 @@ class TestCmrLint(unittest.TestCase):
         self.assertIn('conda-forge', template)
     
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
     def test_generate_fix_suggestions(self):
         """Test generating fix suggestions for various issues."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
         with patch('cmr_lint.getpass.getuser', return_value='testuser'):
             # Test when all checks fail
             suggestions = cmr_lint.generate_fix_suggestions(False, False, False, False, False, False)
-        
+
         self.assertTrue(len(suggestions) > 0)
         suggestion_text = ' '.join(suggestions)
         self.assertIn('condarc', suggestion_text)
         self.assertIn('symlink', suggestion_text)
-        self.assertIn('PIXI_CACHE_DIR', suggestion_text)
+        self.assertIn('~/.cache/rattler', suggestion_text)
         self.assertIn('detached pixi environments', suggestion_text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
@@ -317,8 +320,8 @@ class TestCmrLint(unittest.TestCase):
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {}, clear=False)
-    def test_generate_fix_suggestions_pixi_cache_deletion(self):
-        """A misplaced cache dir (via config) yields a cache.root fix and a deletion hint."""
+    def test_generate_fix_suggestions_pixi_cache_symlink(self):
+        """A misplaced cache dir yields a ~/.cache/rattler symlink suggestion."""
         os.environ.pop('PIXI_CACHE_DIR', None)
         os.environ.pop('RATTLER_CACHE_DIR', None)
         with patch('cmr_lint.getpass.getuser', return_value='testuser'):
@@ -326,28 +329,30 @@ class TestCmrLint(unittest.TestCase):
                 True, True, True, True, False, True,
                 pixi_cache_dir='/tmp/pixi-cache')
         text = '\n'.join(suggestions)
-        self.assertIn('pixi config set --global cache.root', text)
+        self.assertIn('ln -s /pkg/cmr/testuser/pixi/cache ~/.cache/rattler', text)
+        self.assertIn('rm -rf ~/.cache/rattler', text)
+        # The misplaced dir is not the default cache, so it is also flagged for removal.
         self.assertIn('rm -rf /tmp/pixi-cache', text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {'PIXI_CACHE_DIR': '/tmp/pixi-cache'}, clear=False)
     def test_generate_fix_suggestions_pixi_cache_env_override(self):
-        """When a bad env var overrides cache.root, tell the user to fix the env var."""
+        """A bad env var overrides the default cache, so the symlink alone won't help."""
         os.environ.pop('RATTLER_CACHE_DIR', None)
         with patch('cmr_lint.getpass.getuser', return_value='testuser'):
             suggestions = cmr_lint.generate_fix_suggestions(
                 True, True, True, True, False, True,
                 pixi_cache_dir='/tmp/pixi-cache')
         text = '\n'.join(suggestions)
-        # It must point at the overriding env var, not just cache.root, because
-        # cache.root would be ineffective while the env var is set.
-        self.assertIn('PIXI_CACHE_DIR currently overrides', text)
-        self.assertIn('export PIXI_CACHE_DIR=', text)
+        # The symlink is still suggested, but the overriding env var must be flagged.
+        self.assertIn('ln -s /pkg/cmr/testuser/pixi/cache ~/.cache/rattler', text)
+        self.assertIn('PIXI_CACHE_DIR', text)
+        self.assertIn('overrides the default', text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {}, clear=False)
     def test_generate_fix_suggestions_pixi_cache_quoted_rm(self):
-        """A cache path with whitespace is shell-quoted in the rm suggestion."""
+        """A misplaced cache path with whitespace is shell-quoted in the rm suggestion."""
         os.environ.pop('PIXI_CACHE_DIR', None)
         os.environ.pop('RATTLER_CACHE_DIR', None)
         with patch('cmr_lint.getpass.getuser', return_value='testuser'):

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -541,6 +541,24 @@ class TestCmrLint(unittest.TestCase):
         self.assertIn('rm -rf /tmp/pixi-cache', text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
+    def test_generate_fix_suggestions_pixi_cache_broad_root_no_rm(self):
+        """A broad cache.root like ~/.cache must not get a literal rm -rf."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        broad = os.path.expanduser('~/.cache')
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
+                patch('cmr_lint.pixi_config_scope_for_cache_key', return_value=('--global', '')):
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir=broad)
+        text = '\n'.join(suggestions)
+        # Fix the config, but do NOT propose wiping the shared ~/.cache dir.
+        self.assertIn('pixi config set --global cache.root', text)
+        self.assertNotIn(f'rm -rf {broad}', text)
+        self.assertIn('manually', text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {'PIXI_CACHE_DIR': '/tmp/pixi-cache'}, clear=False)
     def test_generate_fix_suggestions_pixi_cache_env_override(self):
         """A bad env var overrides cache.root and the default, so fix the env var."""
@@ -586,12 +604,19 @@ class TestCmrLint(unittest.TestCase):
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_looks_like_pixi_cache_dir(self):
-        """The rm-guard recognizes cache dirs but not broad roots."""
+        """The rm-guard recognizes dedicated pixi/rattler dirs but not broad roots."""
+        # Dedicated pixi/rattler leaf dirs.
         self.assertTrue(cmr_lint.looks_like_pixi_cache_dir('/tmp/pixi-cache'))
         self.assertTrue(cmr_lint.looks_like_pixi_cache_dir('/home/u/.cache/rattler'))
         self.assertTrue(cmr_lint.looks_like_pixi_cache_dir('/some/where/pixi'))
+        # pixi's default cache: `cache` leaf under a rattler/pixi parent.
+        self.assertTrue(cmr_lint.looks_like_pixi_cache_dir('/home/u/.cache/rattler/cache'))
+        self.assertTrue(cmr_lint.looks_like_pixi_cache_dir('/x/pixi/cache'))
+        # Broad roots / shared cache dirs must NOT be accepted (would rm -rf too much).
         self.assertFalse(cmr_lint.looks_like_pixi_cache_dir('/home/testuser'))
         self.assertFalse(cmr_lint.looks_like_pixi_cache_dir('/tmp'))
+        self.assertFalse(cmr_lint.looks_like_pixi_cache_dir('/home/u/.cache'))
+        self.assertFalse(cmr_lint.looks_like_pixi_cache_dir('/var/cache'))
         self.assertFalse(cmr_lint.looks_like_pixi_cache_dir(''))
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -361,6 +361,22 @@ class TestCmrLint(unittest.TestCase):
             self.assertTrue(cmr_lint.is_within_weka('~/conda/envs'))
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
+    def test_find_local_pixi_config(self):
+        """A config file outside the global pixi dirs is reported as local."""
+        os.environ.pop('PIXI_HOME', None)
+        home = os.path.expanduser('~')
+        # Only a global config -> no local config.
+        with patch('cmr_lint.get_pixi_config_locations',
+                   return_value=[os.path.join(home, '.pixi', 'config.toml')]):
+            self.assertIsNone(cmr_lint.find_local_pixi_config())
+        # A workspace-local config present -> returned.
+        with patch('cmr_lint.get_pixi_config_locations',
+                   return_value=[os.path.join(home, '.pixi', 'config.toml'),
+                                 '/proj/.pixi/config.toml']):
+            self.assertEqual(cmr_lint.find_local_pixi_config(), '/proj/.pixi/config.toml')
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_get_pixi_cache_dir_prefers_pixi_info(self):
         """get_pixi_cache_dir uses the cache_dir reported by `pixi info --json`."""
         with patch('cmr_lint.run_command',
@@ -404,6 +420,7 @@ class TestCmrLint(unittest.TestCase):
         os.environ.pop('RATTLER_CACHE_DIR', None)
         overrides = [('config cache.conda-packages', '/home/testuser/cpkgs')]
         with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
+                patch('cmr_lint.find_local_pixi_config', return_value=None), \
                 patch('cmr_lint.find_misplaced_pixi_cache_overrides', return_value=overrides):
             suggestions = cmr_lint.generate_fix_suggestions(
                 True, True, True, True, False, True,
@@ -413,6 +430,28 @@ class TestCmrLint(unittest.TestCase):
         self.assertNotIn('ln -s', text)
         self.assertNotIn('cache.root', text)
         self.assertIn('pixi config unset --global cache.conda-packages', text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
+    def test_generate_fix_suggestions_pixi_cache_local_config_scope(self):
+        """A workspace-local pixi config makes cache fixes target --local, not --global."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        local = '/proj/.pixi/config.toml'
+        overrides = [('config cache.conda-packages', '/home/testuser/cpkgs')]
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
+                patch('cmr_lint.find_local_pixi_config', return_value=local), \
+                patch('cmr_lint.find_misplaced_pixi_cache_overrides', return_value=overrides):
+            # Bad cache.root (config-derived) plus a per-kind override; both should
+            # use --local because the effective config is workspace-local.
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir='/tmp/localbad')
+        text = '\n'.join(suggestions)
+        self.assertIn('pixi config set --local cache.root', text)
+        self.assertIn('pixi config unset --local cache.conda-packages', text)
+        self.assertIn(local, text)
+        self.assertNotIn('--global cache.root', text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch.dict(os.environ, {}, clear=False)
@@ -436,7 +475,8 @@ class TestCmrLint(unittest.TestCase):
         """A bad cache.root (not the default location) yields a cache.root fix, not a symlink."""
         os.environ.pop('PIXI_CACHE_DIR', None)
         os.environ.pop('RATTLER_CACHE_DIR', None)
-        with patch('cmr_lint.getpass.getuser', return_value='testuser'):
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'), \
+                patch('cmr_lint.find_local_pixi_config', return_value=None):
             suggestions = cmr_lint.generate_fix_suggestions(
                 True, True, True, True, False, True,
                 pixi_cache_dir='/tmp/pixi-cache')

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -337,6 +337,17 @@ class TestCmrLint(unittest.TestCase):
         self.assertEqual(misplaced, [('config cache.conda-packages', '/home/testuser/cpkgs')])
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {'PIXI_CACHE_CONDA_PACKAGES_DIR': '/pkg/cmr/testuser/cpkgs'}, clear=False)
+    def test_find_misplaced_pixi_cache_overrides_env_shadows_config(self):
+        """A compliant per-kind env var shadows a bad config value (env wins)."""
+        # Bad cache.conda-packages config, but the matching env var is compliant
+        # and takes precedence, so nothing should be flagged.
+        config = {'cache': {'conda-packages': '/home/testuser/cpkgs'}}
+        with patch('cmr_lint.load_pixi_config', return_value=(config, None)):
+            misplaced = cmr_lint.find_misplaced_pixi_cache_overrides()
+        self.assertEqual(misplaced, [])
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     def test_pixi_config_scope_for_cache_key(self):
         """Scope is --local only when the offending key is defined in a local config."""
         local = str(Path(self.test_dir) / '.pixi' / 'config.toml')

--- a/tests/test_cmr_lint.py
+++ b/tests/test_cmr_lint.py
@@ -316,8 +316,11 @@ class TestCmrLint(unittest.TestCase):
         self.assertEqual(source, 'PIXI_CACHE_DIR')
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
     def test_generate_fix_suggestions_pixi_cache_deletion(self):
-        """A misplaced cache dir yields a cache.root config fix and a deletion hint."""
+        """A misplaced cache dir (via config) yields a cache.root fix and a deletion hint."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
         with patch('cmr_lint.getpass.getuser', return_value='testuser'):
             suggestions = cmr_lint.generate_fix_suggestions(
                 True, True, True, True, False, True,
@@ -325,6 +328,34 @@ class TestCmrLint(unittest.TestCase):
         text = '\n'.join(suggestions)
         self.assertIn('pixi config set --global cache.root', text)
         self.assertIn('rm -rf /tmp/pixi-cache', text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {'PIXI_CACHE_DIR': '/tmp/pixi-cache'}, clear=False)
+    def test_generate_fix_suggestions_pixi_cache_env_override(self):
+        """When a bad env var overrides cache.root, tell the user to fix the env var."""
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'):
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir='/tmp/pixi-cache')
+        text = '\n'.join(suggestions)
+        # It must point at the overriding env var, not just cache.root, because
+        # cache.root would be ineffective while the env var is set.
+        self.assertIn('PIXI_CACHE_DIR currently overrides', text)
+        self.assertIn('export PIXI_CACHE_DIR=', text)
+
+    @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
+    @patch.dict(os.environ, {}, clear=False)
+    def test_generate_fix_suggestions_pixi_cache_quoted_rm(self):
+        """A cache path with whitespace is shell-quoted in the rm suggestion."""
+        os.environ.pop('PIXI_CACHE_DIR', None)
+        os.environ.pop('RATTLER_CACHE_DIR', None)
+        with patch('cmr_lint.getpass.getuser', return_value='testuser'):
+            suggestions = cmr_lint.generate_fix_suggestions(
+                True, True, True, True, False, True,
+                pixi_cache_dir='/tmp/pixi cache')
+        text = '\n'.join(suggestions)
+        self.assertIn("rm -rf '/tmp/pixi cache'", text)
 
     @unittest.skipIf(cmr_lint is None, "Could not import cmr_lint module")
     @patch('cmr_lint.subprocess.run')


### PR DESCRIPTION
## What

Improve `mqlint`'s pixi cache check so it inspects the **effective** cache dir and gives actionable fix instructions.

- Determine the cache dir via `pixi info --json` (its `cache_dir` field), which accounts for both the `PIXI_CACHE_DIR`/`RATTLER_CACHE_DIR` env vars **and** the `cache.root` config key. Previously only the env vars were read, so a cache set through pixi config was silently missed. Falls back to the env vars when pixi can't be run.
- When the cache dir isn't within `/pkg/cmr` or `/mnt/weka`, suggest a config update — `pixi config set --global cache.root /mnt/weka/pkg/cmr/$USER/pixi/cache` — and how to delete the current (misplaced) cache dir (`rm -rf <detected-dir>`).

The correct target stays `/pkg/cmr` or `/mnt/weka` (scratch was considered but is not where the pixi cache belongs).

## Testing

- `python3 -m unittest tests.test_cmr_lint` — 33 tests, all pass.
- Added tests for the pixi-info detection path, the env-var fallback, and the deletion suggestion; updated the cache-dir tests for the new `(ok, cache_dir, message)` return shape.
- Also fixes 4 pre-existing test failures that referenced a removed `--pixi` flag (pixi checks are now unconditional).
- Verified end-to-end by running `bin/mqlint` against both a bad `PIXI_CACHE_DIR` and a bad `cache.root` config value — both are flagged with the config-set + deletion suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)