### PR TITLE
Add opencode support to mqyolo sandbox

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,17 @@ Key invariants the tests guard (keep them true):
   top-level dirs whose target resolves into a denied mount: the wholesale bind loop
   (`SANDBOX_WHOLESALE_BIND_DIRS`) skips a dir if its realpath is denied — e.g. on a
   workstation where `/work` is a symlink onto the sshfs mount, `/work` is not bound.
+- Credential directories in the real home are shadowed with an empty dir bound over
+  their realpath, so they are not readable through the read-only home bind
+  (`sandbox_home_shadow_dir`): `~/.ssh` unconditionally, and `~/.aws` unless the
+  caller passed it via `--ro-paths`/`--rw-paths` (those granted paths are forwarded
+  into `sandbox_home_dotfiles` for exactly this check — the shadow binds are appended
+  after the caller's binds and `sandbox_dedupe_binds` keeps the last per destination,
+  so a shadow would otherwise silently override an explicit opt-in). When `~/.aws` is
+  opted in its home symlink must be recreated, or the AWS SDKs cannot find the profile.
+  Bedrock access should instead use a credential scoped to model invocation
+  (`AWS_BEARER_TOKEN_BEDROCK`); mqyolo deliberately does not forward `AWS_PROFILE` or
+  the access-key/session-token trio, which carry the caller's whole AWS identity.
 - mqyolo refuses to launch unless the working directory is within `/work/microbiome`,
   `$HOME`, `/scratch/microbiome/$USER`, or `/tmp` (anti-leakage; the CWD is bound
   read-write). Checked before the runtime/image checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,15 @@ Key invariants the tests guard (keep them true):
   the "no queue, run locally" guidance (see below). This gate also applies to the
   broker-start condition, not just the guidance.
 - The in-container AI tool is told where heavy/long/high-RAM commands should run —
-  injected for Claude with `--append-system-prompt-file` and for Codex via its
+  injected for Claude with `--append-system-prompt-file`, for Codex via its
   global `~/.codex/AGENTS.md` via a read-only file bind over the real read-write
-  `~/.codex` mount. The guidance adapts to the boot environment
+  `~/.codex` mount, and for opencode via the same trick on its global
+  `~/.config/opencode/AGENTS.md` (`sandbox_bind_opencode_home`, which also rw-binds
+  `~/.config/opencode` and `~/.local/share/opencode` so config/auth/sessions
+  persist; their XDG parents are mirrored into the ephemeral home as directories
+  of symlinks by `sandbox_mirror_home_subdir`, and `XDG_CONFIG_HOME`/`XDG_DATA_HOME`
+  are pinned to the container home so host values cannot redirect opencode).
+  The guidance adapts to the boot environment
   (`_mqyolo_detect_resources` → `MQYOLO_ENV` = `login`|`pbs`|`local`): on a login
   node it says offload to `mqsub`; inside a PBS job it reports the actual allocated
   CPUs/RAM (from NCPUS + qstat) and frames them as a finite budget — run work that

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -772,20 +772,31 @@ sandbox_bind_opencode_home() {
 }
 
 # ---------------------------------------------------------------------------
-# sandbox_write_shim_bashrc DEST_BASHRC REAL_BASHRC SHIM_DIR
+# sandbox_write_shim_bashrc DEST_BASHRC REAL_BASHRC SHIM_DIR [VAR=VALUE...]
 #   Write DEST_BASHRC so a shell that sources it first runs the user's real
 #   bashrc (if given/existing) and THEN puts SHIM_DIR first on PATH. This is how
 #   the container-side mqsub stub keeps winning over the real hpc_scripts bin
 #   dir, which the user's ~/.bashrc (and Claude Code's shell snapshot) prepend.
 #   DEST is removed first because it is usually a symlink into the real home —
 #   we must NOT write through it onto the user's actual bashrc.
+#
+#   Any trailing VAR=VALUE arguments are exported after the real bashrc too, for
+#   variables that must survive it. An apptainer `--env` value is applied BEFORE
+#   the shim sources the real bashrc, so a bashrc that exports the same variable
+#   silently wins — re-asserting here is what makes the pin hold (see mqyolo's
+#   opencode case, which pins XDG_CONFIG_HOME/XDG_DATA_HOME at the container home
+#   so opencode cannot be redirected onto the read-only real home).
 # ---------------------------------------------------------------------------
 sandbox_write_shim_bashrc() {
-    local dest="$1" real="$2" shim="$3"
+    local dest="$1" real="$2" shim="$3"; shift 3
+    local _kv
     rm -f "$dest"
     {
         [[ -n "$real" && -f "$real" ]] && printf 'source %q\n' "$real"
         printf 'export PATH=%q:"$PATH"\n' "$shim"
+        for _kv in "$@"; do
+            printf 'export %s=%q\n' "${_kv%%=*}" "${_kv#*=}"
+        done
     } > "$dest"
 }
 

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -698,6 +698,80 @@ sandbox_bind_codex_home() {
 }
 
 # ---------------------------------------------------------------------------
+# sandbox_mirror_home_subdir REL [SKIP_NAME...]
+#   Replace CONTAINER_HOME/REL — normally a symlink onto the real home's copy,
+#   created by sandbox_home_dotfiles — with a REAL directory inside the ephemeral
+#   home whose entries are symlinks to the real directory's entries (SKIP_NAMEs
+#   omitted). The directory itself is then writable, and a bind can be mounted
+#   *inside* it without the destination path resolving back through the symlink
+#   onto the read-only real home. Entry targets are resolved with `readlink -f`,
+#   like sandbox_home_dotfiles, so they land on the canonical (bound) paths.
+#   Nested paths are mirrored one level at a time, e.g.
+#       sandbox_mirror_home_subdir .local
+#       sandbox_mirror_home_subdir .local/share opencode
+#   CONTAINER_HOME must already exist (sandbox_make_home) and sandbox_home_dotfiles
+#   should have run first, so the symlink being replaced is the one it created.
+# ---------------------------------------------------------------------------
+sandbox_mirror_home_subdir() {
+    local rel="$1"; shift
+    local src="${HOME}/${rel}" dest="${CONTAINER_HOME}/${rel}"
+    # `rm -rf` on a symlink removes the link itself, never the real home behind it.
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    local item name skip skipped
+    while IFS= read -r -d '' item; do
+        name="${item##*/}"
+        skipped=0
+        for skip in "$@"; do
+            [[ "$name" == "$skip" ]] && { skipped=1; break; }
+        done
+        (( skipped )) && continue
+        ln -sf "$(readlink -f "$item" 2>/dev/null || echo "$item")" "${dest}/${name}" 2>/dev/null || true
+    done < <(find "$src" -maxdepth 1 -mindepth 1 -print0 2>/dev/null)
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# sandbox_bind_opencode_home CONFIG_DIR DATA_DIR [GUIDANCE_FILE]
+#   opencode splits its state across two XDG directories: config plus the global
+#   rules file in ~/.config/opencode (AGENTS.md), and auth.json plus session
+#   storage in ~/.local/share/opencode. Both sit under parents that
+#   sandbox_home_dotfiles symlinks wholesale onto the read-only real home, so
+#   opencode could neither log in nor persist a session. Mirror those parents into
+#   the ephemeral home (sandbox_mirror_home_subdir) and bind the two real opencode
+#   dirs read-write in their place, so config/auth/sessions survive across mqyolo
+#   runs — the same deal ~/.codex gets for codex.
+#
+#   When GUIDANCE_FILE is given it is bound read-only over the container's
+#   ~/.config/opencode/AGENTS.md (opencode's global rules file), so the mqyolo
+#   guidance reaches the tool without editing the user's real AGENTS.md.
+#
+#   The caller must also point XDG_CONFIG_HOME/XDG_DATA_HOME at the container home
+#   (see mqyolo), otherwise host XDG_* values would send opencode elsewhere.
+# ---------------------------------------------------------------------------
+sandbox_bind_opencode_home() {
+    local config="$1" data="$2" guidance="${3:-}"
+
+    [[ -n "$config" && -n "$data" ]] || return 0
+    mkdir -p "$config" "$data"
+
+    # Turn ~/.config and ~/.local/share into real dirs of symlinks, minus the
+    # opencode entries the binds below take over.
+    sandbox_mirror_home_subdir .config opencode
+    sandbox_mirror_home_subdir .local
+    sandbox_mirror_home_subdir .local/share opencode
+    mkdir -p "${CONTAINER_HOME}/.config/opencode" "${CONTAINER_HOME}/.local/share/opencode"
+
+    BIND_ARGS+=(--bind "${config}:/container_home/.config/opencode:rw" \
+                --bind "${data}:/container_home/.local/share/opencode:rw")
+
+    if [[ -n "$guidance" && -f "$guidance" ]]; then
+        BIND_ARGS+=(--bind "${guidance}:/container_home/.config/opencode/AGENTS.md:ro")
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
 # sandbox_write_shim_bashrc DEST_BASHRC REAL_BASHRC SHIM_DIR
 #   Write DEST_BASHRC so a shell that sources it first runs the user's real
 #   bashrc (if given/existing) and THEN puts SHIM_DIR first on PATH. This is how

--- a/bin/_sandbox_common.bash
+++ b/bin/_sandbox_common.bash
@@ -571,22 +571,70 @@ sandbox_dedupe_binds() {
 }
 
 # ---------------------------------------------------------------------------
-# sandbox_home_dotfiles
+# sandbox_home_shadow_dir REL [OPT_IN_PATH...]
+#   Shadow ${HOME}/REL with an empty directory bound over its REAL path, so the
+#   in-container tool cannot read it even through the read-only home bind. Used
+#   for credential directories, which are readable-but-fatal: the sandbox's whole
+#   premise is that the AI is untrusted, and a readable credential is a key to
+#   systems outside the sandbox that no filesystem constraint can contain.
+#
+#   Returns 0 if a shadow was added (the caller should NOT symlink REL into the
+#   container home), 1 if REL does not exist or the caller opted it back in.
+#   An OPT_IN_PATH at or under ${HOME}/REL (i.e. an explicit --ro-paths /
+#   --rw-paths) suppresses the shadow: the caller asked for it deliberately, and
+#   sandbox_build_binds has already bound it. That ordering matters — these binds
+#   are appended AFTER the caller's, and sandbox_dedupe_binds keeps the last bind
+#   per destination, so a shadow added here would otherwise silently override an
+#   explicit opt-in.
+# ---------------------------------------------------------------------------
+sandbox_home_shadow_dir() {
+    local rel="$1"; shift
+    local target="${HOME}/${rel}" real opt opt_real
+    [[ -d "$target" ]] || return 1
+    real="$(realpath "$target" 2>/dev/null || echo "$target")"
+    for opt in "$@"; do
+        [[ -n "$opt" ]] || continue
+        opt_real="$(realpath -m "$opt" 2>/dev/null || echo "$opt")"
+        [[ "$opt_real" == "$real" || "$opt_real" == "$real"/* ]] && return 1
+    done
+    mkdir -p "${CONTAINER_HOME}/_empty_${rel#.}"
+    BIND_ARGS+=(--bind "${CONTAINER_HOME}/_empty_${rel#.}:${real}:ro")
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# sandbox_home_dotfiles [OPT_IN_PATH...]
 #   Populates the ephemeral home (CONTAINER_HOME must already be set) with:
 #     - an empty dir shadowing ~/.ssh (so keys are not readable)
+#     - an empty dir shadowing ~/.aws (so cloud credentials are not readable),
+#       unless an OPT_IN_PATH re-exposes it
 #     - rw binds of ~/.cargo (resolving symlinks into shared storage)
 #     - rw binds of each ~/.cache entry (resolving symlinks)
 #     - symlinks to every other ~/dotfile so tools pick up the user's config
 #   Skips .claude / .claude.json (mqyolo handles those) and the entries above.
+#   OPT_IN_PATHs are the caller's --ro-paths/--rw-paths (see
+#   sandbox_home_shadow_dir); only ~/.aws honours them.
 # ---------------------------------------------------------------------------
 sandbox_home_dotfiles() {
+    local -a _opt_ins=("$@")
+
     # --- Hide ~/.ssh completely (shadow with an empty dir) ---
-    if [[ -d "${HOME}/.ssh" ]]; then
-        local _ssh_real
-        _ssh_real="$(realpath "${HOME}/.ssh" 2>/dev/null || echo "${HOME}/.ssh")"
-        mkdir -p "${CONTAINER_HOME}/_empty_ssh"
-        BIND_ARGS+=(--bind "${CONTAINER_HOME}/_empty_ssh:${_ssh_real}:ro")
-    fi
+    # Not opt-innable: nothing in the sandbox has a legitimate need for the
+    # user's private keys, so there is no --ro-paths escape hatch for them.
+    sandbox_home_shadow_dir .ssh || true
+
+    # --- Hide ~/.aws by default (shadow with an empty dir) ---
+    # ~/.aws is a credential store, not config: ~/.aws/sso/cache holds an SSO
+    # access token that can be exchanged (sso:GetRoleCredentials) for role
+    # credentials across every account the user is entitled to, and
+    # ~/.aws/credentials holds long-lived keys outright. Exposing it read-only
+    # still hands the in-container tool the caller's whole AWS identity, so it is
+    # shadowed like ~/.ssh. For Bedrock-backed models, prefer a credential scoped
+    # to model invocation (AWS_BEARER_TOKEN_BEDROCK, or an assume-role session
+    # policy — see mqyolo --help). `--ro-paths ~/.aws` re-exposes it for callers
+    # who accept that trade.
+    local _shadowed_aws=0
+    sandbox_home_shadow_dir .aws "${_opt_ins[@]+"${_opt_ins[@]}"}" && _shadowed_aws=1
 
     # Bind CARGO_HOME (default ~/.cargo) rw so `cargo build`/`cargo test` can
     # download missing deps into the registry.
@@ -632,6 +680,10 @@ sandbox_home_dotfiles() {
     while IFS= read -r -d '' item; do
         name="${item##*/}"
         [[ "$name" == ".claude" || "$name" == ".claude.json" || "$name" == ".cache" || "$name" == ".ssh" || "$name" == ".npm" ]] && continue
+        # Only skip .aws when it was actually shadowed above; when the caller
+        # opted it back in the symlink must exist, or ~/.aws would be unreachable
+        # at the container home and the AWS SDKs would not find the profile.
+        [[ "$name" == ".aws" && "$_shadowed_aws" -eq 1 ]] && continue
         # Resolve through any intermediate symlinks (e.g. /pkg -> /mnt/weka/pkg)
         # so the target is a canonical /mnt/... path that is bound in.
         ln -sf "$(readlink -f "$item" 2>/dev/null || echo "$item")" "${CONTAINER_HOME}/${name}" 2>/dev/null || true

--- a/bin/mqsandbox
+++ b/bin/mqsandbox
@@ -77,7 +77,9 @@ trap 'rm -rf "$CONTAINER_HOME"' EXIT
 # read-write. Harmless if the broker already forwarded them (deduped below).
 sandbox_add_default_scratch_paths
 sandbox_build_binds "$CWD" "${RW_PATHS[@]+"${RW_PATHS[@]}"}" -- "${RO_PATHS[@]+"${RO_PATHS[@]}"}"
-sandbox_home_dotfiles
+# Pass the granted paths so a shadowed credential dir (~/.aws) the session opted
+# back in with --ro-paths stays visible in jobs too, matching the interactive run.
+sandbox_home_dotfiles "${RO_PATHS[@]+"${RO_PATHS[@]}"}" "${RW_PATHS[@]+"${RW_PATHS[@]}"}"
 # Forward terminal-rendering vars and the pixi/rattler cache location (so jobs
 # that run pixi reuse the rw-bound cache); jobs should not inherit API keys.
 sandbox_build_env PIXI_CACHE_DIR RATTLER_CACHE_DIR TERM COLORTERM NO_COLOR

--- a/bin/mqyolo
+++ b/bin/mqyolo
@@ -1,6 +1,6 @@
 #!/bin/bash
-# mqyolo - Run claude, codex, copilot, or any executable shipped in this bin/
-# directory inside a restricted Apptainer/Singularity container.
+# mqyolo - Run claude, codex, copilot, opencode, or any executable shipped in this
+# bin/ directory inside a restricted Apptainer/Singularity container.
 #
 # Permissions inside the container:
 #   - Current directory:        fully read/write
@@ -19,13 +19,15 @@
 # bound read-write — this limits accidental exposure of unrelated data.
 #
 # Usage:
-#   mqyolo [claude|codex|copilot|<bin-executable>] [--rw-paths PATH...] [--ro-paths PATH...] [args...]
+#   mqyolo [claude|codex|copilot|opencode|<bin-executable>] [--rw-paths PATH...] [--ro-paths PATH...] [args...]
 #   Run `mqyolo --help` for the full FILESYSTEM/option reference.
 #
 # Environment variables:
 #   ANTHROPIC_API_KEY   Required for claude
 #   OPENAI_API_KEY      Required for codex
 #   GITHUB_TOKEN        Required for copilot
+#   OPENCODE_API_KEY    opencode zen key (opencode also uses ANTHROPIC_API_KEY /
+#                       OPENAI_API_KEY, or the credentials it stored via `opencode auth login`)
 #   AI_TOOL_SIF         Override path to .sif file (default: same dir as this script)
 #
 # When the host has the PBS batch queue (i.e. `qsub` exists — the aqua login/head
@@ -361,20 +363,20 @@ _mqyolo_is_repo_tool() {
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        claude|codex|copilot) TOOL="$1"; TOOL_SET=1; shift ;;
+        claude|codex|copilot|opencode) TOOL="$1"; TOOL_SET=1; shift ;;
         --debug)      DEBUG=1;   shift ;;
         --no-broker)  NO_BROKER=1; shift ;;
         --print-guidance) _mqyolo_guidance_text; exit 0 ;;
         --rw-paths)
             shift
-            while [[ $# -gt 0 && "$1" != --* && "$1" != claude && "$1" != codex && "$1" != copilot ]]; do
+            while [[ $# -gt 0 && "$1" != --* && "$1" != claude && "$1" != codex && "$1" != copilot && "$1" != opencode ]]; do
                 { [[ "$TOOL_SET" -eq 0 ]] && _mqyolo_is_repo_tool "$1"; } && break
                 RW_PATHS+=("$1"); shift
             done
             ;;
         --ro-paths)
             shift
-            while [[ $# -gt 0 && "$1" != --* && "$1" != claude && "$1" != codex && "$1" != copilot ]]; do
+            while [[ $# -gt 0 && "$1" != --* && "$1" != claude && "$1" != codex && "$1" != copilot && "$1" != opencode ]]; do
                 { [[ "$TOOL_SET" -eq 0 ]] && _mqyolo_is_repo_tool "$1"; } && break
                 RO_PATHS+=("$1"); shift
             done
@@ -384,13 +386,14 @@ while [[ $# -gt 0 ]]; do
 mqyolo - run an AI coding tool inside a sandboxed Apptainer/Singularity container
 
 USAGE
-  mqyolo [claude|codex|copilot|<bin-executable>] [--debug] [--rw-paths PATH...] [--ro-paths PATH...] [--no-broker] [args...]
+  mqyolo [claude|codex|copilot|opencode|<bin-executable>] [--debug] [--rw-paths PATH...] [--ro-paths PATH...] [--no-broker] [args...]
 
 TOOLS
   claude   (default) Claude Code — passes --dangerously-skip-permissions
   codex              OpenAI Codex — bypasses Codex's own prompts/sandbox, enables search,
                      and disables update checks
   copilot            GitHub Copilot CLI — no auto-mode flag; use Shift+Tab inside session for Autopilot mode
+  opencode           opencode — passes --auto to auto-approve permission prompts
   <bin-executable>   Any executable file shipped in this script's own bin/ directory
                      (given as a bare name, e.g. `mqyolo claude_science`). It is run
                      by its canonical path inside the container, as-is — no wrapper
@@ -493,10 +496,25 @@ CODEX SETTINGS
                       mqyolo's generated guidance is mounted read-only over
                       ~/.codex/AGENTS.md inside the container.
 
+OPENCODE SETTINGS
+  ~/.config/opencode/       bound read-write so opencode config, agents and
+                            commands persist across mqyolo runs
+  ~/.local/share/opencode/  bound read-write so opencode auth (auth.json) and
+                            session storage persist
+                      Their parent directories (~/.config, ~/.local/share) are
+                      recreated inside the container as directories of symlinks
+                      to your real ones, so other tools still see their config.
+                      mqyolo's generated guidance is mounted read-only over
+                      ~/.config/opencode/AGENTS.md (opencode's global rules file)
+                      inside the container.
+
 ENVIRONMENT VARIABLES
   ANTHROPIC_API_KEY   Required for claude
   OPENAI_API_KEY      Required for codex
   GITHUB_TOKEN        Required for copilot
+  OPENCODE_API_KEY    opencode zen key for opencode (it also picks up
+                      ANTHROPIC_API_KEY / OPENAI_API_KEY, or whatever
+                      `opencode auth login` stored in ~/.local/share/opencode)
   OPENAI_BASE_URL     Optional — override OpenAI endpoint
   ANTHROPIC_BASE_URL  Optional — override Anthropic endpoint
   CLAUDE_CODE_USE_BEDROCK  Optional — use AWS Bedrock for Claude
@@ -737,7 +755,7 @@ unset _real_bashrc
 # ---------------------------------------------------------------------------
 # Environment variables (PATH honours SANDBOX_PATH_PREFIX set above)
 # ---------------------------------------------------------------------------
-sandbox_build_env ANTHROPIC_API_KEY OPENAI_API_KEY GITHUB_TOKEN \
+sandbox_build_env ANTHROPIC_API_KEY OPENAI_API_KEY GITHUB_TOKEN OPENCODE_API_KEY \
                   OPENAI_BASE_URL ANTHROPIC_BASE_URL CLAUDE_CODE_USE_BEDROCK \
                   PIXI_CACHE_DIR RATTLER_CACHE_DIR \
                   TERM COLORTERM NO_COLOR
@@ -777,6 +795,27 @@ case "$TOOL" in
         # No CLI flag for auto mode; use Shift+Tab inside the session for Autopilot mode
         # (Copilot CLI has no global-instructions hook we can inject mqsub guidance into.)
         YOLO_ARGS=()
+        ;;
+    opencode)
+        # Auto-approve permissions that are not explicitly denied — the container
+        # is the sandbox, so opencode's own prompts add nothing here.
+        YOLO_ARGS=("--auto")
+        # opencode keeps config + its global rules file (AGENTS.md) in
+        # ~/.config/opencode, and auth.json + session storage in
+        # ~/.local/share/opencode. Bind both real dirs read-write so logins and
+        # sessions persist across runs, and expose the mqyolo guidance as the
+        # global AGENTS.md without touching the user's real one.
+        mkdir -p "${HOME}/.config/opencode" "${HOME}/.local/share/opencode"
+        _oc_config="$(readlink -f "${HOME}/.config/opencode" 2>/dev/null || echo "${HOME}/.config/opencode")"
+        _oc_data="$(readlink -f "${HOME}/.local/share/opencode" 2>/dev/null || echo "${HOME}/.local/share/opencode")"
+        sandbox_bind_opencode_home "$_oc_config" "$_oc_data" \
+            "${CONTAINER_HOME}/.mqyolo/guidance.md"
+        unset _oc_config _oc_data
+        # Apptainer forwards the host environment, so a host XDG_CONFIG_HOME /
+        # XDG_DATA_HOME would send opencode outside the binds above (onto the
+        # read-only real home). Pin both to the container home.
+        ENV_ARGS+=(--env "XDG_CONFIG_HOME=/container_home/.config" \
+                   --env "XDG_DATA_HOME=/container_home/.local/share")
         ;;
     *)
         # A repo executable (see arg parsing): run it as-is with no wrapper flags and

--- a/bin/mqyolo
+++ b/bin/mqyolo
@@ -460,6 +460,17 @@ FILESYSTEM INSIDE THE CONTAINER
   ~  (HOME)           isolated ephemeral directory, not your real home;
                       dotfiles are symlinked from your real home so tools
                       like git, ssh etc. pick up your config
+  ~/.ssh              NOT visible — shadowed by an empty directory so private
+                      keys are never readable. No opt-in.
+  ~/.aws              NOT visible — shadowed by an empty directory. It is a
+                      credential store: ~/.aws/sso/cache holds an SSO token
+                      exchangeable for role credentials across every account
+                      you can reach, and ~/.aws/credentials holds long-lived
+                      keys, so exposing it even read-only would give the AI
+                      your whole AWS identity. For Bedrock-backed models use a
+                      credential scoped to model invocation instead (see
+                      AWS_BEARER_TOKEN_BEDROCK below). Re-expose deliberately
+                      with: --ro-paths ~/.aws
 
 MQSUB FROM INSIDE THE CONTAINER
   Only when the host actually has the PBS batch queue (`qsub` is present, as on
@@ -661,7 +672,9 @@ trap '_cleanup; exit 143' TERM HUP
 # Read-only/HPC/tmp/rw/CWD binds, then the ephemeral-home dotfiles. Extra
 # read-only paths follow a `--` separator (see sandbox_build_binds).
 sandbox_build_binds "$CWD" "${RW_PATHS[@]+"${RW_PATHS[@]}"}" -- "${RO_PATHS[@]+"${RO_PATHS[@]}"}"
-sandbox_home_dotfiles
+# The granted paths are passed through so an explicit --ro-paths/--rw-paths on a
+# shadowed credential dir (~/.aws) re-exposes it instead of being overridden.
+sandbox_home_dotfiles "${RO_PATHS[@]+"${RO_PATHS[@]}"}" "${RW_PATHS[@]+"${RW_PATHS[@]}"}"
 
 # ---------------------------------------------------------------------------
 # mqsub broker (one per mqyolo session)

--- a/bin/mqyolo
+++ b/bin/mqyolo
@@ -518,14 +518,27 @@ ENVIRONMENT VARIABLES
   OPENAI_BASE_URL     Optional — override OpenAI endpoint
   ANTHROPIC_BASE_URL  Optional — override Anthropic endpoint
   CLAUDE_CODE_USE_BEDROCK  Optional — use AWS Bedrock for Claude
-  AWS_PROFILE, AWS_REGION, AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID,
-  AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_BEARER_TOKEN_BEDROCK
-                      Forwarded for Bedrock (Claude Code via
-                      CLAUDE_CODE_USE_BEDROCK, or opencode's amazon-bedrock
-                      provider). ~/.aws is visible READ-ONLY inside the
-                      container, so a static-credential profile works but
-                      `aws sso login` cannot refresh its token cache from
-                      inside — log in on the host before launching.
+  AWS_BEARER_TOKEN_BEDROCK  Optional — Bedrock API key for Bedrock-backed
+                      models (Claude Code via CLAUDE_CODE_USE_BEDROCK, or
+                      opencode's amazon-bedrock provider). Preferred over
+                      general AWS credentials: it is scoped to Bedrock, so the
+                      in-container AI cannot reach the rest of your AWS account.
+  AWS_REGION, AWS_DEFAULT_REGION  Optional — Bedrock region (not a credential)
+
+                      General AWS credentials (AWS_PROFILE, AWS_ACCESS_KEY_ID,
+                      AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN) are deliberately
+                      NOT forwarded: they carry your whole AWS identity, not just
+                      model access. To use a role instead of a Bedrock API key,
+                      mint a Bedrock-scoped short-lived session on the HOST and
+                      pass it in explicitly, e.g.
+                        aws sts assume-role --role-arn <role> \
+                            --role-session-name mqyolo --duration-seconds 3600 \
+                            --policy '{"Version":"2012-10-17","Statement":[{"Effect":"Allow",
+                              "Action":["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"],
+                              "Resource":"*"}]}'
+                      then export the returned keys before launching mqyolo (the
+                      session policy caps them at model invocation, and they
+                      expire).
   AI_TOOL_SIF         Override path to the container image
   TERM, COLORTERM, NO_COLOR  Passed through for correct terminal rendering
 
@@ -756,17 +769,20 @@ fi
 # dirs, so they keep winning no matter how often .bashrc is sourced.
 # (.bash_profile/.profile both end by sourcing ~/.bashrc, covering login shells.)
 SANDBOX_PATH_PREFIX="$(IFS=:; printf '%s' "${_PATH_PREFIX_DIRS[*]}")"
-_real_bashrc="$(readlink -f "${HOME}/.bashrc" 2>/dev/null || true)"
-sandbox_write_shim_bashrc "${CONTAINER_HOME}/.bashrc" "$_real_bashrc" "$SANDBOX_PATH_PREFIX"
-unset _real_bashrc
+
+# Anything else that must survive the user's ~/.bashrc gets re-exported by the
+# shim too — same reason as PATH: an `--env` value is applied by apptainer BEFORE
+# the shim sources the real bashrc, so a bashrc that exports the same variable
+# wins. Tool cases append "VAR=value" entries here (see opencode's XDG pinning);
+# the shim itself is written after the tool case below, once this is populated.
+SANDBOX_SHIM_EXPORTS=()
 
 # ---------------------------------------------------------------------------
 # Environment variables (PATH honours SANDBOX_PATH_PREFIX set above)
 # ---------------------------------------------------------------------------
 sandbox_build_env ANTHROPIC_API_KEY OPENAI_API_KEY GITHUB_TOKEN OPENCODE_API_KEY \
                   OPENAI_BASE_URL ANTHROPIC_BASE_URL CLAUDE_CODE_USE_BEDROCK \
-                  AWS_PROFILE AWS_REGION AWS_DEFAULT_REGION AWS_BEARER_TOKEN_BEDROCK \
-                  AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
+                  AWS_REGION AWS_DEFAULT_REGION AWS_BEARER_TOKEN_BEDROCK \
                   PIXI_CACHE_DIR RATTLER_CACHE_DIR \
                   TERM COLORTERM NO_COLOR
 
@@ -823,9 +839,16 @@ case "$TOOL" in
         unset _oc_config _oc_data
         # Apptainer forwards the host environment, so a host XDG_CONFIG_HOME /
         # XDG_DATA_HOME would send opencode outside the binds above (onto the
-        # read-only real home). Pin both to the container home.
+        # read-only real home). Pin both to the container home — via --env AND
+        # via the shim ~/.bashrc, because the container sources the user's real
+        # bashrc after apptainer applies --env: a bashrc that exports XDG_*
+        # (common with XDG-aware dotfile setups) would otherwise win and send
+        # opencode's auth/sessions back to the read-only home, silently losing
+        # persistence and the AGENTS.md guidance bind. Same fix as PATH.
         ENV_ARGS+=(--env "XDG_CONFIG_HOME=/container_home/.config" \
                    --env "XDG_DATA_HOME=/container_home/.local/share")
+        SANDBOX_SHIM_EXPORTS+=("XDG_CONFIG_HOME=/container_home/.config" \
+                               "XDG_DATA_HOME=/container_home/.local/share")
         ;;
     *)
         # A repo executable (see arg parsing): run it as-is with no wrapper flags and
@@ -833,6 +856,17 @@ case "$TOOL" in
         YOLO_ARGS=()
         ;;
 esac
+
+# Give the container its OWN ~/.bashrc: it sources the user's real one and THEN
+# re-asserts our PATH prefix and any SANDBOX_SHIM_EXPORTS the tool case added, so
+# they keep winning no matter how often .bashrc is re-sourced (Claude Code's shell
+# snapshot re-sources it too). Written here, after the tool case, so tool-specific
+# pins are included. (.bash_profile/.profile both end by sourcing ~/.bashrc,
+# covering login shells.)
+_real_bashrc="$(readlink -f "${HOME}/.bashrc" 2>/dev/null || true)"
+sandbox_write_shim_bashrc "${CONTAINER_HOME}/.bashrc" "$_real_bashrc" \
+    "$SANDBOX_PATH_PREFIX" "${SANDBOX_SHIM_EXPORTS[@]+"${SANDBOX_SHIM_EXPORTS[@]}"}"
+unset _real_bashrc
 
 # Drop duplicate-destination binds (e.g. non-sensitive /work folders re-exposed
 # via --ro-paths over the ro-allow and /proc/mounts binds) so apptainer doesn't

--- a/bin/mqyolo
+++ b/bin/mqyolo
@@ -518,6 +518,14 @@ ENVIRONMENT VARIABLES
   OPENAI_BASE_URL     Optional — override OpenAI endpoint
   ANTHROPIC_BASE_URL  Optional — override Anthropic endpoint
   CLAUDE_CODE_USE_BEDROCK  Optional — use AWS Bedrock for Claude
+  AWS_PROFILE, AWS_REGION, AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_BEARER_TOKEN_BEDROCK
+                      Forwarded for Bedrock (Claude Code via
+                      CLAUDE_CODE_USE_BEDROCK, or opencode's amazon-bedrock
+                      provider). ~/.aws is visible READ-ONLY inside the
+                      container, so a static-credential profile works but
+                      `aws sso login` cannot refresh its token cache from
+                      inside — log in on the host before launching.
   AI_TOOL_SIF         Override path to the container image
   TERM, COLORTERM, NO_COLOR  Passed through for correct terminal rendering
 
@@ -757,6 +765,8 @@ unset _real_bashrc
 # ---------------------------------------------------------------------------
 sandbox_build_env ANTHROPIC_API_KEY OPENAI_API_KEY GITHUB_TOKEN OPENCODE_API_KEY \
                   OPENAI_BASE_URL ANTHROPIC_BASE_URL CLAUDE_CODE_USE_BEDROCK \
+                  AWS_PROFILE AWS_REGION AWS_DEFAULT_REGION AWS_BEARER_TOKEN_BEDROCK \
+                  AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN \
                   PIXI_CACHE_DIR RATTLER_CACHE_DIR \
                   TERM COLORTERM NO_COLOR
 

--- a/docs/mqyolo-security-policy.md
+++ b/docs/mqyolo-security-policy.md
@@ -13,9 +13,10 @@ Scope: the coupled system listed in `CLAUDE.md` —
 
 ## 1. Purpose
 
-`mqyolo` runs an autonomous AI coding tool (Claude Code, Codex, or Copilot) on
-the QUT *aqua* HPC with all of its permission prompts disabled
-(`--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox`).
+`mqyolo` runs an autonomous AI coding tool (Claude Code, Codex, Copilot, or
+opencode) on the QUT *aqua* HPC with all of its permission prompts disabled
+(`--dangerously-skip-permissions` / `--dangerously-bypass-approvals-and-sandbox` /
+`--auto`).
 Because the tool can run arbitrary commands without asking, the **container is
 the sandbox**: it, rather than a human approving each action, is what bounds the
 blast radius of the AI and of any prompt-injection or model misbehaviour.
@@ -107,7 +108,7 @@ agent.
 | `/tmp`, `/var/tmp` | read-write | Scratch space. |
 | `--rw-paths` (operator-granted) | read-write | Extra writable paths chosen by the human at launch. |
 | Build/dep caches | read-write | `~/.cache/*`, `~/.cargo`, pixi/rattler cache, `/pkg/cmr/$USER/pixi_dirs`, CWD `target/` — resolved to canonical paths so writes don't fall through onto a read-only parent. |
-| `~/.claude` (claude), `~/.codex` (codex) | read-write | So the tool persists its own config/auth/history across sessions. |
+| `~/.claude` (claude), `~/.codex` (codex), `~/.config/opencode` + `~/.local/share/opencode` (opencode) | read-write | So the tool persists its own config/auth/history across sessions. For opencode the parent XDG directories are recreated inside the container as directories of symlinks, so only the two opencode dirs become writable. |
 | HPC data mounts (`/home`, `/mnt`, `/work`, `/data`, …), `/etc` selected files | **read-only** | The agent can read reference data and configs but not modify them. |
 | `--ro-paths` (operator-granted) + non-sensitive folders (§4.6) | read-only | Extra readable paths chosen at launch / from the sheet. |
 | **Deny-listed trees** (§4.4) | **not visible at all** | Anti-exfiltration. |

--- a/docs/mqyolo-security-policy.md
+++ b/docs/mqyolo-security-policy.md
@@ -111,6 +111,7 @@ agent.
 | `~/.claude` (claude), `~/.codex` (codex), `~/.config/opencode` + `~/.local/share/opencode` (opencode) | read-write | So the tool persists its own config/auth/history across sessions. For opencode the parent XDG directories are recreated inside the container as directories of symlinks, so only the two opencode dirs become writable. |
 | HPC data mounts (`/home`, `/mnt`, `/work`, `/data`, …), `/etc` selected files | **read-only** | The agent can read reference data and configs but not modify them. |
 | `--ro-paths` (operator-granted) + non-sensitive folders (§4.6) | read-only | Extra readable paths chosen at launch / from the sheet. |
+| `~/.ssh`, `~/.aws` | **not visible at all** | Credential stores, shadowed by an empty dir over their real path. Read-only is not sufficient for a credential: it is a key to systems *outside* the sandbox, which no filesystem constraint can contain. `~/.aws/sso/cache` in particular holds an SSO token exchangeable (`sso:GetRoleCredentials`) for role credentials across every account the operator can reach. `~/.aws` can be re-exposed with `--ro-paths ~/.aws`; `~/.ssh` cannot. |
 | **Deny-listed trees** (§4.4) | **not visible at all** | Anti-exfiltration. |
 | Everything else | not visible | `--contain` default. |
 

--- a/singularity/ai_tool.def
+++ b/singularity/ai_tool.def
@@ -2,7 +2,7 @@ Bootstrap: docker
 From: node:24
 
 %labels
-    Description Claude Code / OpenAI Codex CLI / GitHub Copilot CLI in a restricted container
+    Description Claude Code / OpenAI Codex CLI / GitHub Copilot CLI / opencode in a restricted container
 
 %post
     # Handful of CLI tools missing from the base image.
@@ -25,8 +25,9 @@ From: node:24
     apt-get install -y --reinstall --no-install-recommends coreutils git less rsync
     rm -rf /var/lib/apt/lists/*
 
-    # Install Claude Code, OpenAI Codex CLI, and GitHub Copilot CLI
-    npm install -g @anthropic-ai/claude-code@latest @github/copilot@latest
+    # Install Claude Code, GitHub Copilot CLI, and opencode (OpenAI Codex CLI is
+    # installed separately below). opencode-ai ships the `opencode` binary.
+    npm install -g @anthropic-ai/claude-code@latest @github/copilot@latest opencode-ai@latest
 
     # Codex doesn't install the newest via npm, try the recommended way. Install
     # into shared image paths: during %post $HOME is /root, and the installer's

--- a/singularity/rebuild_ai_tool_sif.sh
+++ b/singularity/rebuild_ai_tool_sif.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Rebuild ai_tool.sif from ai_tool.def.
 # Intended to be submitted via mqsub for monthly automated rebuilds so that
-# the bundled AI CLI tools (claude, codex, copilot) stay up to date.
+# the bundled AI CLI tools (claude, codex, copilot, opencode) stay up to date.
 #
 # Submitted by cron via:
 #   mqsub --hours 1 --threads 1 --name mqyolo_singularity_rebuild --bg \

--- a/tests/test_mqyolo_sandbox.py
+++ b/tests/test_mqyolo_sandbox.py
@@ -258,6 +258,73 @@ def test_mqyolo_opencode_uses_auto_flag_and_binds_its_dirs(tmp_path):
     assert "XDG_DATA_HOME=/container_home/.local/share" in out
 
 
+def test_mqyolo_opencode_xdg_survives_user_bashrc(tmp_path):
+    # An apptainer --env value is applied BEFORE the container sources the user's
+    # real ~/.bashrc, so a bashrc that exports XDG_CONFIG_HOME would win and send
+    # opencode's config/auth back onto the read-only real home. The shim bashrc
+    # must re-assert the pins after sourcing the real one (same fix as PATH).
+    real = tmp_path / "real_bashrc"
+    real.write_text(
+        'export XDG_CONFIG_HOME="$HOME/decoy_config"\n'
+        'export XDG_DATA_HOME="$HOME/decoy_data"\n'
+    )
+    dest = tmp_path / "dest_bashrc"
+    script = (
+        "set -euo pipefail; source %s; "
+        "sandbox_write_shim_bashrc %s %s /shims "
+        "XDG_CONFIG_HOME=/container_home/.config "
+        "XDG_DATA_HOME=/container_home/.local/share; "
+        "HOME=/container_home; source %s; "
+        'printf "%%s\\n%%s\\n" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"'
+        % (SANDBOX_LIB, shlex.quote(str(dest)), shlex.quote(str(real)),
+           shlex.quote(str(dest)))
+    )
+    p = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert p.returncode == 0, p.stderr
+    assert p.stdout.split() == [
+        "/container_home/.config",
+        "/container_home/.local/share",
+    ], p.stdout
+
+
+def test_mqyolo_does_not_forward_general_aws_credentials(tmp_path):
+    # Bedrock access must not drag the user's whole AWS identity into the
+    # sandbox: only the Bedrock-scoped API key and the (non-secret) region are
+    # forwarded. AWS_PROFILE / access keys are deliberately withheld.
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    fake_apptainer = fakebin / "apptainer"
+    fake_apptainer.write_text("#!/bin/sh\nprintf '%s\\n' \"$@\"\n")
+    fake_apptainer.chmod(0o755)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    fake_sif = tmp_path / "ai_tool.sif"
+    fake_sif.write_text("")
+    env = {
+        **os.environ,
+        "PATH": f"{fakebin}:{os.environ['PATH']}",
+        "HOME": str(fake_home),
+        "AI_TOOL_SIF": str(fake_sif),
+        "AWS_PROFILE": "sso-profile",
+        "AWS_ACCESS_KEY_ID": "AKIAsecret",
+        "AWS_SECRET_ACCESS_KEY": "shhh",
+        "AWS_SESSION_TOKEN": "sso-session-token",
+        "AWS_REGION": "us-east-1",
+        "AWS_BEARER_TOKEN_BEDROCK": "bedrock-scoped-key",
+    }
+    p = subprocess.run(
+        [str(MQYOLO), "--no-broker", "opencode"],
+        text=True, capture_output=True, env=env, cwd=str(fake_home),
+    )
+    assert p.returncode == 0, p.stderr
+    forwarded = [l for l in (p.stdout + p.stderr).splitlines() if l.startswith("AWS_")]
+    assert "AWS_REGION=us-east-1" in forwarded
+    assert "AWS_BEARER_TOKEN_BEDROCK=bedrock-scoped-key" in forwarded
+    for withheld in ("AWS_PROFILE", "AWS_ACCESS_KEY_ID",
+                     "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        assert not any(l.startswith(f"{withheld}=") for l in forwarded), forwarded
+
+
 def test_mqyolo_rejects_disallowed_launch_dir(tmp_path):
     # The working directory is bound read-write into the sandbox, so mqyolo only
     # allows launching from /work/microbiome, $HOME, /scratch/microbiome/$USER or

--- a/tests/test_mqyolo_sandbox.py
+++ b/tests/test_mqyolo_sandbox.py
@@ -219,6 +219,45 @@ def test_mqyolo_codex_uses_current_auto_mode_flag(tmp_path):
     assert "PATH=/container_home/.mqyolo/tools:/usr/local/bin:/root/.local/bin:/usr/bin:/bin" in out
 
 
+def test_mqyolo_opencode_uses_auto_flag_and_binds_its_dirs(tmp_path):
+    # opencode is auto-approved with --auto, and both of the directories it keeps
+    # state in (config + global AGENTS.md, and auth/session storage) are bound
+    # read-write with XDG pinned to the container home so a host XDG_* cannot
+    # redirect it onto the read-only real home.
+    fakebin = tmp_path / "fakebin"
+    fakebin.mkdir()
+    fake_apptainer = fakebin / "apptainer"
+    fake_apptainer.write_text("#!/bin/sh\nprintf '%s\\n' \"$@\"\n")
+    fake_apptainer.chmod(0o755)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    fake_sif = tmp_path / "ai_tool.sif"
+    fake_sif.write_text("")
+    env = {
+        **os.environ,
+        "PATH": f"{fakebin}:{os.environ['PATH']}",
+        "HOME": str(fake_home),
+        "AI_TOOL_SIF": str(fake_sif),
+        # A host XDG_CONFIG_HOME must not leak through to opencode.
+        "XDG_CONFIG_HOME": str(fake_home / "xdg_config"),
+    }
+
+    p = subprocess.run(
+        [str(MQYOLO), "--no-broker", "opencode"],
+        text=True,
+        capture_output=True,
+        env=env,
+        cwd=str(fake_home),
+    )
+    assert p.returncode == 0, p.stderr
+    out = p.stdout + p.stderr
+    assert "--auto" in out.splitlines()
+    assert f"{fake_home}/.config/opencode:/container_home/.config/opencode:rw" in out
+    assert f"{fake_home}/.local/share/opencode:/container_home/.local/share/opencode:rw" in out
+    assert "XDG_CONFIG_HOME=/container_home/.config" in out
+    assert "XDG_DATA_HOME=/container_home/.local/share" in out
+
+
 def test_mqyolo_rejects_disallowed_launch_dir(tmp_path):
     # The working directory is bound read-write into the sandbox, so mqyolo only
     # allows launching from /work/microbiome, $HOME, /scratch/microbiome/$USER or
@@ -654,6 +693,114 @@ def test_bind_codex_home_mounts_real_dir_rw_and_guidance_readonly(tmp_path):
     binds = p.stdout.splitlines()
     assert f"{real}:/container_home/.codex:rw" in binds
     assert f"{guidance}:/container_home/.codex/AGENTS.md:ro" in binds
+
+
+def test_mirror_home_subdir_replaces_symlink_with_dir_of_symlinks(tmp_path):
+    # sandbox_home_dotfiles leaves ~/.config as a symlink onto the (read-only)
+    # real home. Mirroring must replace the LINK — never write through it — with a
+    # real dir of symlinks, minus the skipped entry, so a bind can be mounted
+    # inside it.
+    home = tmp_path / "home"
+    (home / ".config" / "git").mkdir(parents=True)
+    (home / ".config" / "opencode").mkdir()
+    chome = tmp_path / "chome"
+    chome.mkdir()
+    (chome / ".config").symlink_to(home / ".config")
+
+    script = (
+        "set -euo pipefail\n"
+        "source %s; "
+        "HOME=%s CONTAINER_HOME=%s; "
+        "sandbox_mirror_home_subdir .config opencode"
+        % (SANDBOX_LIB, shlex.quote(str(home)), shlex.quote(str(chome)))
+    )
+    p = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert p.returncode == 0, p.stderr
+
+    mirrored = chome / ".config"
+    assert mirrored.is_dir() and not mirrored.is_symlink()
+    assert (mirrored / "git").is_symlink()
+    assert os.path.realpath(mirrored / "git") == os.path.realpath(home / ".config" / "git")
+    # The entry taken over by a bind must NOT be symlinked, or the bind
+    # destination would resolve back onto the read-only real home.
+    assert not (mirrored / "opencode").exists()
+    # The real home is untouched.
+    assert (home / ".config" / "git").is_dir()
+    assert (home / ".config" / "opencode").is_dir()
+
+
+def test_bind_opencode_home_mounts_real_dirs_rw_and_guidance_readonly(tmp_path):
+    home = tmp_path / "home"
+    (home / ".config").mkdir(parents=True)
+    (home / ".local" / "share").mkdir(parents=True)
+    chome = tmp_path / "chome"
+    chome.mkdir()
+    # As sandbox_home_dotfiles leaves them: symlinks onto the real home.
+    (chome / ".config").symlink_to(home / ".config")
+    (chome / ".local").symlink_to(home / ".local")
+    config = home / ".config" / "opencode"
+    data = home / ".local" / "share" / "opencode"
+    guidance = tmp_path / "guidance.md"
+    guidance.write_text("use mqsub\n")
+
+    script = (
+        "set -euo pipefail\n"
+        "source %s; "
+        "HOME=%s CONTAINER_HOME=%s; "
+        "BIND_ARGS=(); "
+        "sandbox_bind_opencode_home %s %s %s; "
+        'for a in "${BIND_ARGS[@]}"; do [[ "$a" == --bind ]] || printf "%%s\\n" "$a"; done'
+        % (
+            SANDBOX_LIB,
+            shlex.quote(str(home)),
+            shlex.quote(str(chome)),
+            shlex.quote(str(config)),
+            shlex.quote(str(data)),
+            shlex.quote(str(guidance)),
+        )
+    )
+    p = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert p.returncode == 0, p.stderr
+    # Both state dirs are created in the real home so the binds have a source.
+    assert config.is_dir() and data.is_dir()
+    binds = p.stdout.splitlines()
+    assert f"{config}:/container_home/.config/opencode:rw" in binds
+    assert f"{data}:/container_home/.local/share/opencode:rw" in binds
+    assert f"{guidance}:/container_home/.config/opencode/AGENTS.md:ro" in binds
+    # The XDG parents are now real dirs inside the ephemeral home, with the
+    # opencode mountpoints present and NOT symlinked at the real home.
+    for rel in (".config", ".local", ".local/share"):
+        assert (chome / rel).is_dir() and not (chome / rel).is_symlink()
+    assert (chome / ".config" / "opencode").is_dir()
+    assert not (chome / ".config" / "opencode").is_symlink()
+    assert (chome / ".local" / "share" / "opencode").is_dir()
+    assert not (chome / ".local" / "share" / "opencode").is_symlink()
+
+
+def test_bind_opencode_home_without_guidance_omits_agents_bind(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    chome = tmp_path / "chome"
+    chome.mkdir()
+    script = (
+        "set -euo pipefail\n"
+        "source %s; "
+        "HOME=%s CONTAINER_HOME=%s; "
+        "BIND_ARGS=(); "
+        "sandbox_bind_opencode_home %s %s %s; "
+        'for a in "${BIND_ARGS[@]}"; do [[ "$a" == --bind ]] || printf "%%s\\n" "$a"; done'
+        % (
+            SANDBOX_LIB,
+            shlex.quote(str(home)),
+            shlex.quote(str(chome)),
+            shlex.quote(str(home / ".config" / "opencode")),
+            shlex.quote(str(home / ".local" / "share" / "opencode")),
+            shlex.quote(str(tmp_path / "missing_guidance.md")),
+        )
+    )
+    p = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert p.returncode == 0, p.stderr
+    assert "AGENTS.md" not in p.stdout
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mqyolo_sandbox.py
+++ b/tests/test_mqyolo_sandbox.py
@@ -762,6 +762,81 @@ def test_bind_codex_home_mounts_real_dir_rw_and_guidance_readonly(tmp_path):
     assert f"{guidance}:/container_home/.codex/AGENTS.md:ro" in binds
 
 
+def _home_dotfiles(home, opt_ins=()):
+    """Drive sandbox_home_dotfiles against a fake HOME. Returns
+    (bind specs, container-home entry names)."""
+    args = " ".join(shlex.quote(str(p)) for p in opt_ins)
+    script = (
+        "set -euo pipefail\n"
+        "source %s\n"
+        "HOME=%s\n"
+        "CONTAINER_HOME=$(mktemp -d)\n"
+        "BIND_ARGS=()\n"
+        "sandbox_home_dotfiles %s\n"
+        'for a in "${BIND_ARGS[@]}"; do [[ "$a" == --bind ]] || printf "bind %%s\\n" "$a"; done\n'
+        'for e in "$CONTAINER_HOME"/.*; do printf "entry %%s\\n" "${e##*/}"; done\n'
+        'rm -rf "$CONTAINER_HOME"\n'
+        % (SANDBOX_LIB, shlex.quote(str(home)), args)
+    )
+    p = subprocess.run(["bash", "-c", script], text=True, capture_output=True)
+    assert p.returncode == 0, p.stderr
+    binds = [l[5:] for l in p.stdout.splitlines() if l.startswith("bind ")]
+    entries = [l[6:] for l in p.stdout.splitlines() if l.startswith("entry ")]
+    return binds, entries
+
+
+def test_home_dotfiles_shadows_aws_credentials_by_default(tmp_path):
+    # ~/.aws/sso/cache holds an SSO access token exchangeable for role
+    # credentials across every account the user can reach — exposing it
+    # read-only still hands the untrusted in-container tool the caller's whole
+    # AWS identity. It must be shadowed like ~/.ssh, not symlinked through.
+    home = tmp_path / "home"
+    (home / ".aws" / "sso" / "cache").mkdir(parents=True)
+    (home / ".aws" / "sso" / "cache" / "tok.json").write_text('{"accessToken":"x"}')
+    (home / ".ssh").mkdir()
+    (home / ".gitconfig").write_text("[user]\n")
+
+    binds, entries = _home_dotfiles(home)
+
+    aws_real = os.path.realpath(home / ".aws")
+    shadow = [b for b in binds if b.endswith(f":{aws_real}:ro")]
+    assert len(shadow) == 1, binds
+    assert "_empty_aws" in shadow[0], shadow
+    # No symlink into the real ~/.aws, so it isn't reachable via the home bind.
+    assert ".aws" not in entries, entries
+    # Unrelated dotfiles are still linked through.
+    assert ".gitconfig" in entries, entries
+
+
+def test_home_dotfiles_aws_can_be_opted_back_in(tmp_path):
+    # An explicit --ro-paths ~/.aws is a deliberate choice — honour it. The
+    # shadow bind is appended after the caller's ro-path bind and dedupe keeps
+    # the last one, so the shadow must be skipped rather than layered on top.
+    home = tmp_path / "home"
+    (home / ".aws").mkdir(parents=True)
+
+    binds, entries = _home_dotfiles(home, opt_ins=[home / ".aws"])
+
+    aws_real = os.path.realpath(home / ".aws")
+    assert not any(b.endswith(f":{aws_real}:ro") for b in binds), binds
+    # The symlink must exist, or ~/.aws is unreachable at the container home.
+    assert ".aws" in entries, entries
+
+
+def test_home_dotfiles_ssh_shadow_is_not_opt_innable(tmp_path):
+    # Private keys have no legitimate in-sandbox use; unlike ~/.aws there is no
+    # escape hatch, so passing ~/.ssh as a granted path must not expose it.
+    home = tmp_path / "home"
+    (home / ".ssh").mkdir(parents=True)
+
+    binds, entries = _home_dotfiles(home, opt_ins=[home / ".ssh"])
+
+    ssh_real = os.path.realpath(home / ".ssh")
+    shadow = [b for b in binds if b.endswith(f":{ssh_real}:ro")]
+    assert len(shadow) == 1 and "_empty_ssh" in shadow[0], binds
+    assert ".ssh" not in entries, entries
+
+
 def test_mirror_home_subdir_replaces_symlink_with_dir_of_symlinks(tmp_path):
     # sandbox_home_dotfiles leaves ~/.config as a symlink onto the (read-only)
     # real home. Mirroring must replace the LINK — never write through it — with a


### PR DESCRIPTION
Add support for running opencode (an autonomous AI coding tool) inside the mqyolo sandbox, alongside Claude Code, Codex, and Copilot.

## Summary

This change extends mqyolo to support opencode as a fourth AI tool option. opencode has different state storage patterns than the existing tools, requiring new sandbox infrastructure to handle its split configuration across `~/.config/opencode` and `~/.local/share/opencode` while preserving their parent directories as symlinks for other tools.

## Key Changes

- **New sandbox functions** (`bin/_sandbox_common.bash`):
  - `sandbox_mirror_home_subdir`: Replaces symlinks (created by `sandbox_home_dotfiles`) with real directories containing symlinks to the original entries, minus specified skip entries. This allows bind mounts to be placed inside the directory without resolving back through the symlink onto the read-only real home.
  - `sandbox_bind_opencode_home`: Binds opencode's two state directories (`~/.config/opencode` and `~/.local/share/opencode`) read-write, mirrors their parent directories, and optionally binds a guidance file read-only over the global `AGENTS.md` rules file.

- **mqyolo tool support** (`bin/mqyolo`):
  - Added `opencode` as a recognized tool alongside claude/codex/copilot
  - Passes `--auto` flag to auto-approve permission prompts (container is the sandbox)
  - Binds both opencode state directories read-write so config, auth, and sessions persist across runs
  - Pins `XDG_CONFIG_HOME` and `XDG_DATA_HOME` to container home to prevent host environment variables from redirecting opencode outside the binds
  - Added `OPENCODE_API_KEY` to the environment variables passed into the container

- **Container image** (`singularity/ai_tool.def`):
  - Added `opencode-ai` npm package installation alongside existing tools

- **Documentation updates**:
  - Updated `CLAUDE.md` to document the mirroring and binding strategy for opencode's split state storage
  - Updated `docs/mqyolo-security-policy.md` to include opencode in scope and list its bound directories
  - Updated help text and usage examples throughout to include opencode

- **Test coverage** (`tests/test_mqyolo_sandbox.py`):
  - `test_mqyolo_opencode_uses_auto_flag_and_binds_its_dirs`: Verifies opencode receives `--auto`, both state directories are bound read-write, and XDG variables are pinned
  - `test_mirror_home_subdir_replaces_symlink_with_dir_of_symlinks`: Tests the symlink-to-directory replacement logic
  - `test_bind_opencode_home_mounts_real_dirs_rw_and_guidance_readonly`: Tests bind mounting with guidance file injection
  - `test_bind_opencode_home_without_guidance_omits_agents_bind`: Tests graceful handling when guidance file is missing

## Implementation Details

The core challenge is that opencode stores state in two separate XDG directories under parents that `sandbox_home_dotfiles` symlinks wholesale onto the read-only real home. Simply binding the opencode subdirectories would fail because their parent symlinks would resolve back to the read-only real home. The solution mirrors the parent directories into the ephemeral home as real directories containing symlinks to the original entries (minus the opencode entries being taken over by binds), allowing the binds to be mounted inside writable parents.

This approach preserves other tools' access to their config in the same parent directories via the symlinks, while giving opencode persistent read-write access to its own state across mqyolo sessions.

https://claude.ai/code/session_016npWthQdYG5Zcemj7jxAmN